### PR TITLE
Use natural heights for student task expand/collapse

### DIFF
--- a/sencha-workspace/SlateTasksStudent/app/controller/Tasks.js
+++ b/sencha-workspace/SlateTasksStudent/app/controller/Tasks.js
@@ -80,6 +80,7 @@ Ext.define('SlateTasksStudent.controller.Tasks', {
 
         me.formatCompetencies(store);
         tree.update({tasks: tasks});
+        tree.afterTasksLoad();
     },
 
     onTaskTreeItemClick: function(id) {

--- a/sencha-workspace/SlateTasksStudent/app/view/TaskTree.js
+++ b/sencha-workspace/SlateTasksStudent/app/view/TaskTree.js
@@ -216,16 +216,33 @@ Ext.define('SlateTasksStudent.view.TaskTree', {
         }
     },
 
+    afterTasksLoad: function() {
+        var tree = this,
+            sublists = tree.el.select('.slate-tasktree-sublist');
+
+        sublists.each(function(sublist) {
+            sublist.set({
+                'data-natural-height': sublist.getHeight(),
+                style: {
+                    height: 0
+                }
+            });
+        });
+    },
+
     onTreeClick: function(ev, t) {
         var target = Ext.get(t),
-            parentEl,recordId;
+            treeItem = target.up('.slate-tasktree-item'),
+            sublist = treeItem.down('.slate-tasktree-sublist'),
+            recordId;
 
-        if (target.is('.slate-tasktree-nub.is-clickable')) {
-            target.up('.slate-tasktree-item').toggleCls('is-expanded');
+        if (target.is('.slate-tasktree-nub.is-clickable') && treeItem && sublist) {
+            var newHeight = treeItem.hasCls('is-expanded') ? 0 : sublist.getAttribute('data-natural-height');
+            sublist.setHeight(newHeight);
+            treeItem.toggleCls('is-expanded');
         } else {
-            parentEl = target.up('.slate-tasktree-item');
-            if (parentEl) {
-                recordId = parentEl.dom.getAttribute('recordId');
+            if (treeItem) {
+                recordId = treeItem.dom.getAttribute('recordId');
                 this.fireEvent('itemclick',recordId);
             }
         }

--- a/sencha-workspace/SlateTasksStudent/sass/src/view/TaskTree.scss
+++ b/sencha-workspace/SlateTasksStudent/sass/src/view/TaskTree.scss
@@ -109,7 +109,6 @@
 }
 
 .slate-tasktree-sublist {
-    height: 0;
     list-style: none;
     margin: 0 0 0 1.5em;
     opacity: 0;
@@ -141,7 +140,6 @@
     }
 
     .is-expanded & {
-        height: 134px; // TODO make this dynamic!
         opacity: 1;
         transform: none;
     }


### PR DESCRIPTION
Not sure my solution is optimal (I ran into race conditions with the DOM rendering, and the `height` transition seems sluggish with a lot of tasks), but it should work for now.
#217
