### PR TITLE
Add fake bottom border to StudentsProgressGrid

### DIFF
--- a/sencha-workspace/SlateDemonstrationsTeacher/sass/src/view/StudentsProgressGrid.scss
+++ b/sencha-workspace/SlateDemonstrationsTeacher/sass/src/view/StudentsProgressGrid.scss
@@ -117,6 +117,19 @@
 .#{$g}-ct {
     @include display-box;
     @include box-orient(horizontal);
+
+    // work around bottom border disappearing
+    position: relative;
+
+    &::before {
+        background-color: $grid-border-color;
+        bottom: 0;
+        content: ' ';
+        height: 1px;
+        left: 0;
+        position: absolute;
+        width: 100%;
+    }
 }
 
 .#{$g}-scroll-ct {


### PR DESCRIPTION
There are some border collapsing issues with the bottom of this component. This code adds a 1px high generated content box to substitute for a bottom border. Hacky, but this component is being replaced anyway.
