### PR TITLE
Fix reports bug

### DIFF
--- a/site-root/cbl/exports/competencies-details.php
+++ b/site-root/cbl/exports/competencies-details.php
@@ -167,8 +167,8 @@ foreach ($students as $student) {
                         }
 
                         // no credit for logs beyond the number required
-                        if ($completedOpportunities > $skill->DemonstrationsRequired) {
-                            $completedOpportunities = $skill->DemonstrationsRequired;
+                        if ($completedOpportunities > $demonstrationsRequired) {
+                            $completedOpportunities = $demonstrationsRequired;
                         }
 
                     }

--- a/site-root/cbl/exports/content-areas.php
+++ b/site-root/cbl/exports/content-areas.php
@@ -169,8 +169,8 @@ foreach ($students as $student) {
                             }
 
                             // no credit for logs beyond the number required
-                            if ($completedOpportunities > $skill->DemonstrationsRequired) {
-                                $completedOpportunities = $skill->DemonstrationsRequired;
+                            if ($completedOpportunities > $demonstrationsRequired) {
+                                $completedOpportunities = $demonstrationsRequired;
                             }
 
                         }


### PR DESCRIPTION
When code was adapted to incorporate the new demonstrations required json field,
the block that prevents credit for logs beyond the number required was not updated
to use the new code.