### PR TITLE
Release: slate-cbl v0.3.9

### DIFF
--- a/site-root/cbl/exports/demonstrations.php
+++ b/site-root/cbl/exports/demonstrations.php
@@ -66,10 +66,10 @@ foreach ($demonstrations AS $Demonstration) {
         $row['Standard'] = $skill->Code;
 
         // For overriden demonstrations, rating should be "O" rather than the DemonstratedLevel
-        if ($DemonstrationSkill->Override==1) {
-            $row['Rating'] = "O";
+        if ($DemonstrationSkill->Override) {
+            $row['Rating'] = 'O';
         } else {
-            $row['Rating'] = $DemonstrationSkill->DemonstratedLevel > 0 ?  $DemonstrationSkill->DemonstratedLevel : 'M';
+            $row['Rating'] = $DemonstrationSkill->DemonstratedLevel > 0 ? $DemonstrationSkill->DemonstratedLevel : 'M';
         }
 
         $row['Level'] = $DemonstrationSkill->TargetLevel;

--- a/site-root/cbl/exports/demonstrations.php
+++ b/site-root/cbl/exports/demonstrations.php
@@ -63,9 +63,17 @@ foreach ($demonstrations AS $Demonstration) {
 
         $row['Competency'] = $skill->Competency->Code;
         $row['Standard'] = $skill->Code;
-        $row['Rating'] = $DemonstrationSkill->DemonstratedLevel > 0 ?  $DemonstrationSkill->DemonstratedLevel : 'M';
+
+        // For overriden demonstrations, rating should be "O" rather than the DemonstratedLevel
+        if ($DemonstrationSkill->Override==1) {
+            $row['Rating'] = "O";
+        } else {
+            $row['Rating'] = $DemonstrationSkill->DemonstratedLevel > 0 ?  $DemonstrationSkill->DemonstratedLevel : 'M';
+        }
+
         $row['Level'] = $DemonstrationSkill->TargetLevel;
         $row['Mapping'] = '';
+
         $sw->writeRow($row);
     }
 }

--- a/site-root/cbl/exports/demonstrations.php
+++ b/site-root/cbl/exports/demonstrations.php
@@ -3,6 +3,7 @@ $GLOBALS['Session']->requireAccountLevel('Staff');
 
 // This was causing a script timeout (30 seconds), this should help speed it up
 \Site::$debug = false;
+set_time_limit(0);
 
 $sw = new SpreadsheetWriter();
 

--- a/site-root/cbl/exports/demonstrations.php
+++ b/site-root/cbl/exports/demonstrations.php
@@ -68,8 +68,10 @@ foreach ($demonstrations AS $Demonstration) {
         // For overriden demonstrations, rating should be "O" rather than the DemonstratedLevel
         if ($DemonstrationSkill->Override) {
             $row['Rating'] = 'O';
+        } elseif ($DemonstrationSkill->DemonstratedLevel > 0) {
+            $row['Rating'] = $DemonstrationSkill->DemonstratedLevel;
         } else {
-            $row['Rating'] = $DemonstrationSkill->DemonstratedLevel > 0 ? $DemonstrationSkill->DemonstratedLevel : 'M';
+            $row['Rating'] = 'M';
         }
 
         $row['Level'] = $DemonstrationSkill->TargetLevel;


### PR DESCRIPTION
- Output overrides correctly in demonstrations export