### PR TITLE
Release: slate-cbl v2.1.6

### DIFF
--- a/php-classes/Slate/CBL/Tasks/StudentTasksRequestHandler.php
+++ b/php-classes/Slate/CBL/Tasks/StudentTasksRequestHandler.php
@@ -286,11 +286,19 @@ class StudentTasksRequestHandler extends \RecordsRequestHandler
 
     protected static function _getRequestedStudent()
     {
-        if (
-            !empty($_GET['student']) &&
-            $GLOBALS['Session']->hasAccountLevel('Staff')
-        ) {
-            if (!$Student = PeopleRequestHandler::getRecordByHandle($_GET['student'])) {
+
+        if (!empty($_GET['student'])) {
+            $Student = PeopleRequestHandler::getRecordByHandle($_GET['student']);
+            $userIsStaff = $GLOBALS['Session']->hasAccountLevel('Staff');
+
+            if ($Student && !$userIsStaff) {
+                $GuardianRelationship = \Emergence\People\GuardianRelationship::getByWhere([
+                    'PersonID' => $Student->ID,
+                    'RelatedPersonID' => $GLOBALS['Session']->PersonID
+                ]);
+            }
+
+            if (!$Student || (!$userIsStaff && !$GuardianRelationship)) {
                 return static::throwNotFoundError('Student not found');
             }
         } else {

--- a/php-config/Slate/UI/Tools.config.d/cbl.php
+++ b/php-config/Slate/UI/Tools.config.d/cbl.php
@@ -27,4 +27,11 @@ if ($GLOBALS['Session']->hasAccountLevel('Staff')) {
     $cblTools['Task Dashboard'] = '/cbl/dashboards/tasks/student';
 }
 
+if ($GLOBALS['Session']->Person && !empty($GLOBALS['Session']->Person->Wards)) {
+    foreach($GLOBALS['Session']->Person->Wards as $Ward) {
+        $cblTools[$Ward->FirstNamePossessive . ' Competency Dashboard'] = '/cbl/dashboards/demonstrations/student?student='.$Ward->Username;
+        $cblTools[$Ward->FirstNamePossessive . ' Task Dashboard'] = '/cbl/dashboards/tasks/student?student='.$Ward->Username;
+    }
+}
+
 Slate\UI\Tools::$tools['Competency-Based Learning'] = $cblTools;

--- a/sencha-workspace/SlateTasksManager/app/view/AppHeader.js
+++ b/sencha-workspace/SlateTasksManager/app/view/AppHeader.js
@@ -7,7 +7,7 @@ Ext.define('SlateTasksManager.view.AppHeader', {
         xtype: 'component',
         cls: 'slate-appheader-title',
         itemId: 'title',
-        html: 'Task Database'
+        html: 'Task Library'
     },
         '->',
     {

--- a/sencha-workspace/SlateTasksManager/app/view/TasksManager.js
+++ b/sencha-workspace/SlateTasksManager/app/view/TasksManager.js
@@ -11,7 +11,7 @@ Ext.define('SlateTasksManager.view.TasksManager', {
     config: {
     },
 
-    title: 'Task Database',
+    title: 'Task Library',
     header: false,
 
     componentCls: 'slate-tasks-manager',

--- a/sencha-workspace/SlateTasksStudent/app/store/CourseSections.js
+++ b/sencha-workspace/SlateTasksStudent/app/store/CourseSections.js
@@ -7,9 +7,11 @@ Ext.define('SlateTasksStudent.store.CourseSections', {
     proxy: {
         type: 'slate-records',
         url: '/sections',
+        include: 'Term',
 
         extraParams: {
-            enrolled_user: 'current'
+            'enrolled_user': 'current',
+            'sort_current': 1
         }
     }
 });

--- a/sencha-workspace/SlateTasksStudent/app/view/AppHeader.js
+++ b/sencha-workspace/SlateTasksStudent/app/view/AppHeader.js
@@ -32,7 +32,27 @@ Ext.define('SlateTasksStudent.view.AppHeader', {
 
             forceSelection: true,
             queryMode: 'local',
-            editable: false
+            editable: false,
+
+            tpl: [
+                '{% this.currentTerm = null %}',
+                '<tpl for=".">',
+                    '{[this.showTermHeader(values)]}',
+                    '<div class="x-boundlist-item">&nbsp;&nbsp;{Title}</div>',
+                '</tpl>',
+                {
+                    showTermHeader: function(section) {
+                        var header = '';
+
+                        if (this.currentTerm !== section.TermID) {
+                            header = '<div class="group-header">'+section.Term ? section.Term.Title : 'Term' +'</div>'
+                        }
+
+                        this.currentTerm = section.TermID;
+                        return header;
+                    }
+                }
+            ]
         },
         {
             xtype: 'tbfill'

--- a/sencha-workspace/SlateTasksStudent/app/view/TaskTree.js
+++ b/sencha-workspace/SlateTasksStudent/app/view/TaskTree.js
@@ -142,25 +142,22 @@ Ext.define('SlateTasksStudent.view.TaskTree', {
                     ],
                     dueDate = data.DueDate,
                     status = data.TaskStatus,
-                    now, isLate;
+                    now, endOfDueDate, isLate;
 
                 if (dueDate) {
                     now = new Date();
-                    dueDate = new Date(dueDate * 1000);
-
+                    endOfDueDate = new Date(dueDate);
                     // task is late after midnight of due date
-                    dueDate.setDate(now.getDate() - 1);
-                    dueDate.setHours(23);
-                    dueDate.setMinutes(59);
-                    dueDate.setSeconds(59);
+                    endOfDueDate.setHours(23);
+                    endOfDueDate.setMinutes(59);
+                    endOfDueDate.setSeconds(59);
 
-                    isLate = activeStatuses.indexOf(status) > -1 && (!dueDate || dueDate < now)
+                    isLate = activeStatuses.indexOf(status) > -1 && endOfDueDate < now;
                 }
 
                 if (isLate) {
                     return statusClasses.late[status] || '';
                 }
-
                 return statusClasses[status] || '';
             }
         }

--- a/sencha-workspace/SlateTasksStudent/app/view/TaskTree.js
+++ b/sencha-workspace/SlateTasksStudent/app/view/TaskTree.js
@@ -86,7 +86,7 @@ Ext.define('SlateTasksStudent.view.TaskTree', {
                         '<ul class="slate-tasktree-sublist">',
 
                             '<tpl for="subtasks">',
-                                '<li class="slate-tasktree-item slate-tasktree-status-{[ this.getDueStatusCls(values) ]}" recordId="{ID}">',
+                                '<li class="slate-tasktree-item slate-tasktree-status-{[ this.getDueStatusCls(values, statusClasses) ]}" recordId="{ID}">',
 
                                     '<div class="flex-ct">',
                                         '<div class="slate-tasktree-nub"></div>',

--- a/sencha-workspace/SlateTasksStudent/sass/src/view/TaskTree.scss
+++ b/sencha-workspace/SlateTasksStudent/sass/src/view/TaskTree.scss
@@ -1,19 +1,23 @@
 @mixin slate-tasktree-item-status($status, $color) {
     &.slate-tasktree-status-#{$status} {
-        .slate-tasktree-nub {
-            background-color: darken($color, 5);
+        > div {
+            .slate-tasktree-nub {
+                background-color: darken($color, 5);
 
-            &.is-clickable:hover {
-                background-color: $color;
+                &.is-clickable:hover {
+                    background-color: $color;
+                }
             }
-        }
 
-        .slate-tasktree-status {
-            background-color: $color;
-        }
+            > .slate-tasktree-data {
+                .slate-tasktree-status {
+                    background-color: $color;
+                }
 
-        .slate-tasktree-date {
-            background-color: lighten($color, 10);
+                .slate-tasktree-date {
+                    background-color: lighten($color, 10);
+                }
+            }
         }
     }
 }

--- a/sencha-workspace/SlateTasksTeacher/app/controller/Dashboard.js
+++ b/sencha-workspace/SlateTasksTeacher/app/controller/Dashboard.js
@@ -537,7 +537,7 @@ Ext.define('SlateTasksTeacher.controller.Dashboard', {
                         // reload record to ensure relationships are included.
                         // todo: remove this when API removes the need
                         rec.load();
-                    }, 500);
+                    }, 1000);
                 }
                 Ext.toast('Task succesfully saved!');
             }

--- a/sencha-workspace/SlateTasksTeacher/app/controller/Dashboard.js
+++ b/sencha-workspace/SlateTasksTeacher/app/controller/Dashboard.js
@@ -424,7 +424,7 @@ Ext.define('SlateTasksTeacher.controller.Dashboard', {
             });
         }
 
-        if (task.getAssigneeIds().length) {
+        if (!task.phantom && task.getAssigneeIds().length) {
             return me.doConfirmTaskAssignees(task);
         }
 

--- a/sencha-workspace/SlateTasksTeacher/app/view/AppHeader.js
+++ b/sencha-workspace/SlateTasksTeacher/app/view/AppHeader.js
@@ -11,7 +11,7 @@ Ext.define('SlateTasksTeacher.view.AppHeader', {
         xtype: 'component',
         cls: 'slate-appheader-title',
         itemId: 'title',
-        html: 'Teacher Task Manager'
+        html: 'Teacher Task Library'
     }, {
         xtype: 'combo',
         itemId: 'sectionSelect',

--- a/sencha-workspace/SlateTasksTeacher/app/view/StudentsGrid.js
+++ b/sencha-workspace/SlateTasksTeacher/app/view/StudentsGrid.js
@@ -233,7 +233,7 @@ Ext.define('SlateTasksTeacher.view.StudentsGrid', {
             cellClasses = ['jarvus-aggregrid-cell', 'slate-studentsgrid-cell'],
             statusClasses = me.getStatusClasses(),
             record,
-            dueDate, status,
+            dueDate, endOfDueDate, status,
             now, isLate;
 
         if (group.records && group.records.length && (record = group.records[0].record)) {
@@ -242,15 +242,14 @@ Ext.define('SlateTasksTeacher.view.StudentsGrid', {
 
             if (dueDate) {
                 now = new Date();
-                dueDate = new Date(dueDate);
+                endOfDueDate = new Date(dueDate);
 
                 // task is late after midnight of due date
-                dueDate.setDate(dueDate.getDate() - 1);
-                dueDate.setHours(23);
-                dueDate.setMinutes(59);
-                dueDate.setSeconds(59);
+                endOfDueDate.setHours(23);
+                endOfDueDate.setMinutes(59);
+                endOfDueDate.setSeconds(59);
 
-                isLate = activeStatuses.indexOf(status) > -1 && (!dueDate || dueDate < now)
+                isLate = activeStatuses.indexOf(status) > -1 && endOfDueDate < now;
             }
 
             if (isLate) {

--- a/sencha-workspace/packages/slate-cbl/src/model/Task.js
+++ b/sencha-workspace/packages/slate-cbl/src/model/Task.js
@@ -156,7 +156,8 @@ Ext.define('Slate.cbl.model.Task', {
             'Creator',
             'ParentTask',
             'Skills',
-            'Attachments'
+            'Attachments',
+            'StudentTasks'
         ]
     },
 


### PR DESCRIPTION
- Add competency and task apps to guardian dashboard
  - Allow guardians to view both SlateDemonstrationStudent & SlateTasksStudent apps for their respective wards.
  - Add student CBL Tools links' to guardian dashboard.
- Add date filtering to exports
- Fix issues with task status coloring
- List sections by year in Student app
- Task Manager renamed to Task Library

