### PR TITLE
Release: slate-cbl v2.1.8

### DIFF
--- a/html-templates/cbl/exports/index.tpl
+++ b/html-templates/cbl/exports/index.tpl
@@ -1,0 +1,18 @@
+{extends designs/site.tpl}
+
+{block content}
+    {foreach from=$data key=scriptName item=script implode="<hr>"}
+        <h2>{$scriptName}</h2>
+
+        <form method="POST" action="/cbl/exports/{$scriptName}">
+            {field inputName=from placeholder="Enter Date" label="Start Time"}
+
+            {field inputName=to placeholder="Enter Date" label="End Time"}
+
+            {field inputName=students placeholder="Students" label=Students}
+
+            <button>Download</button>
+        </form>
+    {/foreach}
+
+{/block}

--- a/php-classes/Slate/CBL/Competency.php
+++ b/php-classes/Slate/CBL/Competency.php
@@ -176,6 +176,8 @@ class Competency extends \VersionedRecord
                 return $levelTotals[$level];
             } else if (array_key_exists('default', $levelTotals)) {
                 return $levelTotals['default'];
+            } else { // handle competencies with no skills 
+                return 0;
             }
         }
 

--- a/php-classes/Slate/CBL/Demonstrations/StudentDashboardRequestHandler.php
+++ b/php-classes/Slate/CBL/Demonstrations/StudentDashboardRequestHandler.php
@@ -212,10 +212,12 @@ class StudentDashboardRequestHandler extends \RequestHandler
                 ]);
             }
 
-            if (!$Student || (!$userIsStaff && !$GuardianRelationship)) {
+            if (!$Student || ($Student->ID != $GLOBALS['Session']->PersonID && !$userIsStaff && !$GuardianRelationship)) {
                 return static::throwNotFoundError('Student not found');
             }
-        } else {
+        }
+
+        if (!$Student) { // automatically set student to session user
             $Student = $GLOBALS['Session']->Person;
         }
 

--- a/php-classes/Slate/CBL/ExportsRequestHandler.php
+++ b/php-classes/Slate/CBL/ExportsRequestHandler.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Slate\CBL;
+
+use Emergence_FS;
+
+class ExportsRequestHandler extends \RequestHandler
+{
+
+    public static function handleRequest()
+    {
+        $GLOBALS['Session']->requireAccountLevel('Staff');
+
+        $scripts = [];
+        foreach (Emergence_FS::getAggregateChildren('site-root/cbl/exports') as $scriptName => $scriptFile) {
+            preg_match('/(.+\.csv)\.php/', $scriptName, $matches);
+            if (!empty($matches)) {
+                $scripts[$matches[1]] = $scriptFile;
+            }
+        }
+
+        return static::respond('index', [
+            'data' => $scripts
+        ]);
+    }
+}

--- a/php-classes/Slate/CBL/Skill.php
+++ b/php-classes/Slate/CBL/Skill.php
@@ -177,4 +177,15 @@ class Skill extends \VersionedRecord
 
         return $level;
     }
+    
+    public function getDemonstrationsRequiredByLevel($level, $returnDefault = true)
+    {
+        if (isset($this->DemonstrationsRequired[$level])) {
+            return $this->DemonstrationsRequired[$level];
+        } else if ($returnDefault) { // return default value if level is not explicitely set.$_COOKIE
+            return $this->DemonstrationsRequired['default'];
+        }
+        
+        return null;
+    }
 }

--- a/php-classes/Slate/CBL/Tasks/StudentTask.php
+++ b/php-classes/Slate/CBL/Tasks/StudentTask.php
@@ -146,6 +146,17 @@ class StudentTask extends \VersionedRecord
         ]
     ];
 
+    public function getValue($name)
+    {
+        switch ($name) {
+            case 'AllSkills':
+                return $this->Skills + ($this->Task ? $this->Task->Skills : []);
+
+            default:
+                return parent::getValue($name);
+        }
+    }
+
     public function getStudentName()
     {
         return $this->Student->FullName;

--- a/php-classes/Slate/CBL/Tasks/StudentTask.php
+++ b/php-classes/Slate/CBL/Tasks/StudentTask.php
@@ -174,11 +174,11 @@ class StudentTask extends \VersionedRecord
 
         if ($this->Task && $this->Task->Skills) {
             foreach ($this->Task->Skills as $skill) {
-                $studentCompetency = $skill->Competency ? StudentCompetency::getByWhere(['StudentID' => $this->StudentID, 'CompetencyID' => $skill->Competency->ID]) : null;
+                $currentLevel = $skill->Competency ? $skill->Competency->getCurrentLevelForStudent($this->Student) : null;
                 $demoSkillRating = $demoSkillIds[$skill->ID] ? $demoSkillIds[$skill->ID]->DemonstratedLevel : null;
 
                 $taskSkills[] = array_merge($skill->getData(), [
-                    'CompetencyLevel' => $studentCompetency ? $studentCompetency->Level : null,
+                    'CompetencyLevel' => $currentLevel,
                     'CompetencyCode' => $skill->Competency ? $skill->Competency->Code : null,
                     'CompetencyDescriptor' => $skill->Competency ? $skill->Competency->Descriptor : null,
                     'Rating' => $demoSkillRating
@@ -188,11 +188,11 @@ class StudentTask extends \VersionedRecord
 
         if ($this->Skills) {
             foreach ($this->Skills as $skill) {
-                $studentCompetency = $skill->Competency ? StudentCompetency::getByWhere(['StudentID' => $this->StudentID, 'CompetencyID' => $skill->Competency->ID]) : null;
+                $currentLevel = $skill->Competency ? $skill->Competency->getCurrentLevelForStudent($this->Student) : null;
                 $demoSkillRating = $demoSkillIds[$skill->ID] ? $demoSkillIds[$skill->ID]->DemonstratedLevel : null;
 
                 $taskSkills[] = array_merge($skill->getData(), [
-                    'CompetencyLevel' => $studentCompetency ? $studentCompetency->Level : null,
+                    'CompetencyLevel' => $currentLevel,
                     'CompetencyCode' => $skill->Competency ? $skill->Competency->Code : null,
                     'CompetencyDescriptor' => $skill->Competency ? $skill->Competency->Descriptor : null,
                     'Rating' => $demoSkillRating

--- a/sencha-workspace/SlateDemonstrationsStudent/app/controller/Dashboard.js
+++ b/sencha-workspace/SlateDemonstrationsStudent/app/controller/Dashboard.js
@@ -42,7 +42,7 @@ Ext.define('SlateDemonstrationsStudent.controller.Dashboard', {
     onLaunch: function () {
         var siteEnv = window.SiteEnvironment || {},
             cblStudentId = (siteEnv.cblStudent || {}).ID,
-            cblContentArea = siteEnv.cblContentArea || null,
+            cblContentArea = siteEnv.cblContentArea || {},
             dashboardCt, recentProgressCmp;
 
         // fetch component instances
@@ -55,7 +55,7 @@ Ext.define('SlateDemonstrationsStudent.controller.Dashboard', {
         }
 
         if (cblContentArea) {
-            recentProgressCmp.setContentAreaId(cblContentArea);
+            recentProgressCmp.setContentAreaId(cblContentArea.ID);
         }
 
         // configure dashboard with any available embedded data

--- a/site-root/cbl/exports/_index.php
+++ b/site-root/cbl/exports/_index.php
@@ -1,0 +1,3 @@
+<?php
+
+\Slate\CBL\ExportsRequestHandler::handleRequest();

--- a/site-root/cbl/exports/competencies-details.csv.php
+++ b/site-root/cbl/exports/competencies-details.csv.php
@@ -96,7 +96,7 @@ foreach ($students as $student) {
                 continue;
             }
 
-            $completion = $competency->getCompletionForStudent($student, $level);
+            $completion = $competency->getCompletionForStudent($student, $level, $defaultDemonstrationConditions[0]);
             $totalER = $competency->getTotalDemonstrationsRequired($level);
 
             // get all skills for this competency

--- a/site-root/cbl/exports/competencies-details.csv.php
+++ b/site-root/cbl/exports/competencies-details.csv.php
@@ -66,7 +66,7 @@ foreach ($students as $student) {
         '  JOIN `%3$s` %4$s'.
         '    ON %2$s.CompetencyID = %4$s.ID'.
         ' WHERE %2$s.StudentID = %5$u'.
-        ' ORDER BY %4$s.Code ASC',
+        ' ORDER BY %2$s.Level, %4$s.Code ASC',
         [
             \Slate\CBL\StudentCompetency::$tableName,
             \Slate\CBL\StudentCompetency::getTableAlias(),

--- a/site-root/cbl/exports/competencies-details.csv.php
+++ b/site-root/cbl/exports/competencies-details.csv.php
@@ -55,8 +55,8 @@ foreach ($students as $student) {
         'ID',
         'SELECT ID FROM `%s` WHERE (%s)',
         [
-            \Slate\CBL\Demonstrations\Demonstration::class::$tableName,
-            join(') AND (',\Slate\CBL\Demonstrations\Demonstration::class::mapConditions($demonstrationConditions))
+            \Slate\CBL\Demonstrations\Demonstration::$tableName,
+            join(') AND (',\Slate\CBL\Demonstrations\Demonstration::mapConditions($demonstrationConditions))
         ]
     );
 

--- a/site-root/cbl/exports/competencies-details.csv.php
+++ b/site-root/cbl/exports/competencies-details.csv.php
@@ -28,9 +28,7 @@ $headers = [
 array_push($rows, $headers);
 
 // retrieve students
-$students = Slate\People\Student::getAllByListIdentifier(empty($_GET['students']) ? 'all' : $_GET['students']);
-
-
+$students = Slate\People\Student::getAllByListIdentifier(empty($_REQUEST['students']) ? 'all' : $_REQUEST['students']);
 
 $format = 'Y-m-d H:i:s';
 

--- a/site-root/cbl/exports/competencies.csv.php
+++ b/site-root/cbl/exports/competencies.csv.php
@@ -5,7 +5,7 @@ $GLOBALS['Session']->requireAccountLevel('Staff');
 
 
 // fetch key objects from database
-$students = Slate\People\Student::getAllByListIdentifier(empty($_GET['students']) ? 'all' : $_GET['students']);
+$students = Slate\People\Student::getAllByListIdentifier(empty($_REQUEST['students']) ? 'all' : $_REQUEST['students']);
 $contentAreas = Slate\CBL\ContentArea::getAll(['order' => 'Code']);
 
 $format = 'Y-m-d H:i:s';

--- a/site-root/cbl/exports/competencies.csv.php
+++ b/site-root/cbl/exports/competencies.csv.php
@@ -15,11 +15,11 @@ $to = $_REQUEST['to'] ? date($format, strtotime($_REQUEST['to'])) : null;
 
 $conditions = '';
 if ($from && $to) {
-    $conditions = sprintf('AND %s.Demonstrated BETWEEN "%s" AND "%s"', \Slate\CBL\Demonstrations\Demonstration::getTableAlias(), $from, $to);
+    $conditions = sprintf('Demonstrated BETWEEN "%s" AND "%s"', $from, $to);
 } else if ($from) {
-    $conditions = sprintf('AND %s.Demonstrated >= "%s"', \Slate\CBL\Demonstrations\Demonstration::getTableAlias(), $from);
+    $conditions = sprintf('Demonstrated >= "%s"', $from);
 } else if ($to) {
-    $conditions = sprintf('AND %s.Demonstrated <= "%s"', \Slate\CBL\Demonstrations\Demonstration::getTableAlias(), $to);
+    $conditions = sprintf('Demonstrated <= "%s"', $to);
 }
 
 // collect counts of all missing demonstrations by student+competency
@@ -45,7 +45,7 @@ try {
         .'   JOIN `%5$s` Skill'
         .'    ON Skill.ID = %4$s.SkillID'
         .'   WHERE %2$s.StudentID IN (%6$s)'
-        .$conditions
+        .'   %7$s'
         .'   GROUP BY %2$s.StudentID, %4$s.SkillID'
         .' ) MissingDemonstrationsByStudentSkill'
         .' GROUP BY StudentID, CompetencyID'
@@ -57,7 +57,8 @@ try {
             Slate\CBL\Skill::$tableName,
             implode(',', array_map(function($Student) {
                 return $Student->ID;
-            }, $students))
+            }, $students)),
+            !empty($conditions) ? sprintf(' AND %s.%s', Slate\CBL\Demonstrations\Demonstration::getTableAlias(), $conditions) : $conditions
         ]
     );
 
@@ -95,17 +96,18 @@ foreach ($contentAreas AS $ContentArea) {
 foreach ($students AS $Student) {
     $uniqueLevels = \DB::allValues(
         'DemonstratedLevel',
-        'SELECT DISTINCT(%4$s.DemonstratedLevel) FROM `%1$s` %2$s '.
+        $query = 'SELECT DISTINCT(%4$s.DemonstratedLevel) FROM `%1$s` %2$s '.
         'RIGHT JOIN `%3$s` %4$s ON (%2$s.ID = %4$s.DemonstrationID) '.
         'WHERE %2$s.StudentID=%5$u AND %4$s.DemonstratedLevel != 0 '.
-        $conditions.
+        '%6$s '.
         ' ORDER BY %4$s.DemonstratedLevel ASC',
-        [
+        $parameters = [
             Slate\CBL\Demonstrations\Demonstration::$tableName,
             Slate\CBL\Demonstrations\Demonstration::getTableAlias(),
             Slate\CBL\Demonstrations\DemonstrationSkill::$tableName,
             Slate\CBL\Demonstrations\DemonstrationSkill::getTableAlias(),
-            $Student->ID
+            $Student->ID,
+            !empty($conditions) ? sprintf(' AND %s.%s', Slate\CBL\Demonstrations\Demonstration::getTableAlias(), $conditions) : $conditions
         ]
     );
 
@@ -116,35 +118,40 @@ foreach ($students AS $Student) {
             $level
         ];
         foreach ($contentAreas AS $ContentArea) {
-            $demonstrationsCounted = 0;
-            $demonstrationsRequired = 0;
-            $demonstrationsMissing = 0;
+            $totalDemonstrationsCounted = 0;
+            $totalDemonstrationsRequired = 0;
+            $totalDemonstrationsMissing = 0;
             $contentAreaAverageTotal = 0;
 
             foreach ($ContentArea->Competencies AS $Competency) {
-                $competencyCompletion = $Competency->getCompletionForStudent($Student, $level);
-                $currentLevel = !empty($competencyCompletion['currentLevel']) ? $competencyCompletion['currentLevel'] : 'default'; // use "default" level for calculating er's if user isn't on any level
-                $totalDemonstrationsRequired = intval($Competency->getTotalDemonstrationsRequired($currentLevel, true));
+                $competencyCompletion = $Competency->getCompletionForStudent($Student, $level, $conditions);
+                $demonstrationsRequired = intval($Competency->getTotalDemonstrationsRequired($level, true));
 
                 // Logged
                 $row[] = intval($competencyCompletion['demonstrationsLogged']);
                 // Total
-                $row[] = $totalDemonstrationsRequired;
+                $row[] = $demonstrationsRequired;
                 // Average
-                $row[] = intval($competencyCompletion['demonstrationsAverage'] ? round($competencyCompletion['demonstrationsAverage'], 2) : null);
-
-                $demonstrationsCounted += $competencyCompletion['demonstrationsLogged'];
-                $demonstrationsRequired += $totalDemonstrationsRequired;
+                $row[] = $competencyCompletion['demonstrationsAverage'] ? round($competencyCompletion['demonstrationsAverage'], 2) : null;
+                $totalDemonstrationsCounted += $competencyCompletion['demonstrationsLogged'];
+                $totalDemonstrationsRequired += $demonstrationsRequired;
 
                 // averages are weighted by number of demonstrations
-                $contentAreaAverageTotal += $competencyCompletion['demonstrationsAverage'] * $competencyCompletion['demonstrationsCount'];
+                $contentAreaAverageTotal += $competencyCompletion['demonstrationsAverage'] * $competencyCompletion['demonstrationsLogged'];
 
                 if(isset($missingDemonstrationsByStudentCompetency[$Student->ID][$Competency->ID])) {
-                    $demonstrationsMissing += $missingDemonstrationsByStudentCompetency[$Student->ID][$Competency->ID];
+                    $totalDemonstrationsMissing += $missingDemonstrationsByStudentCompetency[$Student->ID][$Competency->ID];
                 }
-
-                $row[] = intval($demonstrationsCounted ? round($contentAreaAverageTotal / $demonstrationsCounted, 2) : null);
             }
+
+            // Content Area Logged
+            $row[] = $totalDemonstrationsCounted;
+            // Content Area Required
+            $row[] = $totalDemonstrationsRequired;
+            // Content Area Missing
+            $row[] = $totalDemonstrationsMissing;
+            // Content Area Average
+            $row[] = $totalDemonstrationsCounted ? round($contentAreaAverageTotal / $totalDemonstrationsCounted, 2) : 0;
         }
         $rows[] = $row;
     }

--- a/site-root/cbl/exports/content-areas.csv.php
+++ b/site-root/cbl/exports/content-areas.csv.php
@@ -41,7 +41,7 @@ if ($from && $to) {
 }
 
 // retrieve students
-$students = Slate\People\Student::getAllByListIdentifier(empty($_GET['students']) ? 'all' : $_GET['students']);
+$students = Slate\People\Student::getAllByListIdentifier(empty($_REQUEST['students']) ? 'all' : $_REQUEST['students']);
 
 foreach ($students as $student) {
     $demonstrationConditions = array_merge($defaultDemonstrationConditions, [

--- a/site-root/cbl/exports/content-areas.csv.php
+++ b/site-root/cbl/exports/content-areas.csv.php
@@ -104,7 +104,7 @@ foreach ($students as $student) {
                     continue;
                 }
 
-                $completion = $competency->getCompletionForStudent($student, $competencyLevel);
+                $completion = $competency->getCompletionForStudent($student, $competencyLevel, $defaultDemonstrationConditions[0]);
 
                 $totalER = $totalER + $competency->getTotalDemonstrationsRequired($competencyLevel);
 

--- a/site-root/cbl/exports/demonstrations-legacy.csv.php
+++ b/site-root/cbl/exports/demonstrations-legacy.csv.php
@@ -6,7 +6,7 @@ $GLOBALS['Session']->requireAccountLevel('Staff');
 
 
 // fetch key objects from database
-$students = Slate\People\Student::getAllByListIdentifier(empty($_GET['students']) ? 'all' : $_GET['students']);
+$students = Slate\People\Student::getAllByListIdentifier(empty($_REQUEST['students']) ? 'all' : $_REQUEST['students']);
 $studentIds = array_map(function($s) { return $s->ID; }, $students);
 
 $skills = Slate\CBL\Skill::getAll(['order' => 'Code']);

--- a/site-root/cbl/exports/demonstrations-legacy.csv.php
+++ b/site-root/cbl/exports/demonstrations-legacy.csv.php
@@ -22,7 +22,6 @@ $format = 'Y-m-d H:i:s';
 $from = $_REQUEST['from'] ? date($format, strtotime($_REQUEST['from'])) : null;
 $to = $_REQUEST['to'] ? date($format, strtotime($_REQUEST['to'])) : null;
 
-$demonstrationConditions = [];
 if ($from && $to) {
     $demonstrationConditions[] = sprintf('Demonstrated BETWEEN "%s" AND "%s"', $from, $to);
 } else if ($from) {

--- a/site-root/cbl/exports/demonstrations.csv.php
+++ b/site-root/cbl/exports/demonstrations.csv.php
@@ -38,7 +38,7 @@ if ($from && $to) {
 
 $results = \DB::query(
     'SELECT %2$s.ID, '.
-            '%2$s.Created AS Created, '.
+            'DATE(%2$s.Demonstrated) AS Demonstrated, '.
             'CONCAT(%4$s.FirstName, " ", %4$s.LastName) AS Creator, '.
             '%5$s.StudentNumber AS StudentNumber, '.
             'CONCAT(%5$s.FirstName, " ", %5$s.LastName) AS Student, '.

--- a/site-root/cbl/exports/demonstrations.csv.php
+++ b/site-root/cbl/exports/demonstrations.csv.php
@@ -1,15 +1,21 @@
 <?php
 $GLOBALS['Session']->requireAccountLevel('Staff');
 
+use Emergence\People\Person;
+use Slate\People\Student;
+use Slate\CBL\Skill;
+use Slate\CBL\Demonstrations\Demonstration;
+use Slate\CBL\Demonstrations\DemonstrationSkill;
+
 // This was causing a script timeout (30 seconds), this should help speed it up
 \Site::$debug = false;
 set_time_limit(0);
 
 // fetch key objects from database
-$students = Slate\People\Student::getAllByListIdentifier(empty($_GET['students']) ? 'all' : $_GET['students']);
+$students = Student::getAllByListIdentifier(empty($_GET['students']) ? 'all' : $_GET['students']);
 $studentIds = array_map(function($s) { return $s->ID; }, $students);
 
-$skills = Slate\CBL\Skill::getAll(['indexField' => 'ID']);
+$skills = Skill::getAll(['indexField' => 'ID']);
 
 $demonstrationConditions = [
     'StudentID' => [
@@ -22,7 +28,6 @@ $format = 'Y-m-d H:i:s';
 $from = $_REQUEST['from'] ? date($format, strtotime($_REQUEST['from'])) : null;
 $to = $_REQUEST['to'] ? date($format, strtotime($_REQUEST['to'])) : null;
 
-$demonstrationConditions = [];
 if ($from && $to) {
     $demonstrationConditions[] = sprintf('Demonstrated BETWEEN "%s" AND "%s"', $from, $to);
 } else if ($from) {
@@ -31,30 +36,56 @@ if ($from && $to) {
     $demonstrationConditions[] = sprintf('Demonstrated <= "%s"', $to);
 }
 
-
-$demonstrations = Slate\CBL\Demonstrations\Demonstration::getAllByWhere(
-    $demonstrationConditions,
+$results = \DB::query(
+    'SELECT %2$s.ID, '.
+            '%2$s.Created AS Created, '.
+            'CONCAT(%4$s.FirstName, " ", %4$s.LastName) AS Creator, '.
+            '%5$s.StudentNumber AS StudentNumber, '.
+            'CONCAT(%5$s.FirstName, " ", %5$s.LastName) AS Student, '.
+            '%2$s.ExperienceType, '.
+            '%2$s.Context, '.
+            '%2$s.PerformanceType, '.
+            '%2$s.ArtifactURL '.
+    ' FROM `%1$s` %2$s '.
+    ' JOIN `%3$s` %4$s '.
+    '   ON %2$s.CreatorID = %4$s.ID '.
+    ' JOIN `%3$s` %5$s '.
+    '   ON %2$s.StudentID = %5$s.ID '.
+    'WHERE (%6$s) '.
+    'ORDER BY %2$s.ID',
     [
-        'order' => 'ID'
+        Demonstration::$tableName,
+        Demonstration::getTableAlias(),
+        
+        Person::$tableName,
+        Person::getTableAlias(),
+        
+        'Student',
+        join(') AND (', Demonstration::mapConditions($demonstrationConditions))
     ]
 );
 
-// one row for each demonstration standard
-foreach ($demonstrations AS $Demonstration) {
-    $demonstrationSkills = $Demonstration->Skills;
+$sw = new SpreadsheetWriter();
+// build and output headers list
+$headers = [
+    'Timestamp',
+    'Submitted by',
+    'ID',
+    'Name',
+    'Type of experience',
+    'Context',
+    'Performance task',
+    'Artifact',
+    'Competency',
+    'Standard',
+    'Rating',
+    'Level',
+    'Mapping'
+];
+$sw->writeRow($headers);
 
-    $row = [
-        date('Y-m-d H:i', $Demonstration->Created),
-        $Demonstration->Creator->FullName,
-        $Demonstration->Student->StudentNumber,
-        $Demonstration->Student->FullName,
-        $Demonstration->ExperienceType,
-        $Demonstration->Context,
-        $Demonstration->PerformanceType,
-        $Demonstration->ArtifactURL
-    ];
-    // Don't rebuild the row for each standard demonstrated, just overwrite the last set of values
-    foreach ($demonstrationSkills AS $DemonstrationSkill) {
+while($row = $results->fetch_assoc()) {
+    foreach (DemonstrationSkill::getAllByWhere(['DemonstrationID' => $row['ID']]) AS $DemonstrationSkill) {
         $skill = $DemonstrationSkill->Skill;
 
         $row['Competency'] = $skill->Competency->Code;
@@ -72,28 +103,8 @@ foreach ($demonstrations AS $Demonstration) {
         $row['Level'] = $DemonstrationSkill->TargetLevel;
         $row['Mapping'] = '';
 
-        $rows[] = $row;
-    }
+        $sw->writeRow($row);
+    }   
 }
 
-// build and output headers list
-$headers = [
-    'Timestamp',
-    'Submitted by',
-    'ID',
-    'Name',
-    'Type of experience',
-    'Context',
-    'Performance task',
-    'Artifact',
-    'Competency',
-    'Standard',
-    'Rating',
-    'Level',
-    'Mapping'
-];
-
-$sw = new SpreadsheetWriter();
-$sw->writeRow($headers);
-$sw->writeRows($rows);
 $sw->close();

--- a/site-root/cbl/exports/demonstrations.csv.php
+++ b/site-root/cbl/exports/demonstrations.csv.php
@@ -80,12 +80,11 @@ $headers = [
     'Standard',
     'Rating',
     'Level',
-    'Mapping'
+#    'Mapping'
 ];
 $sw->writeRow($headers);
 
 while($row = $results->fetch_assoc()) {
-    foreach (DemonstrationSkill::getAllByWhere(['DemonstrationID' => $row['ID']]) AS $DemonstrationSkill) {
     $rowId = $row['ID'];
     unset($row['ID']);
     foreach (DemonstrationSkill::getAllByWhere(['DemonstrationID' => $rowId]) AS $DemonstrationSkill) {
@@ -104,10 +103,10 @@ while($row = $results->fetch_assoc()) {
         }
 
         $row['Level'] = $DemonstrationSkill->TargetLevel;
-        $row['Mapping'] = '';
+#        $row['Mapping'] = '';
 
         $sw->writeRow($row);
-    }   
+    }
 }
 
 $sw->close();

--- a/site-root/cbl/exports/demonstrations.csv.php
+++ b/site-root/cbl/exports/demonstrations.csv.php
@@ -86,6 +86,9 @@ $sw->writeRow($headers);
 
 while($row = $results->fetch_assoc()) {
     foreach (DemonstrationSkill::getAllByWhere(['DemonstrationID' => $row['ID']]) AS $DemonstrationSkill) {
+    $rowId = $row['ID'];
+    unset($row['ID']);
+    foreach (DemonstrationSkill::getAllByWhere(['DemonstrationID' => $rowId]) AS $DemonstrationSkill) {
         $skill = $DemonstrationSkill->Skill;
 
         $row['Competency'] = $skill->Competency->Code;

--- a/site-root/cbl/exports/demonstrations.csv.php
+++ b/site-root/cbl/exports/demonstrations.csv.php
@@ -12,7 +12,7 @@ use Slate\CBL\Demonstrations\DemonstrationSkill;
 set_time_limit(0);
 
 // fetch key objects from database
-$students = Student::getAllByListIdentifier(empty($_GET['students']) ? 'all' : $_GET['students']);
+$students = Student::getAllByListIdentifier(empty($_REQUEST['students']) ? 'all' : $_REQUEST['students']);
 $studentIds = array_map(function($s) { return $s->ID; }, $students);
 
 $skills = Skill::getAll(['indexField' => 'ID']);

--- a/site-root/cbl/exports/tasks.csv.php
+++ b/site-root/cbl/exports/tasks.csv.php
@@ -46,6 +46,7 @@ foreach ($studentTasks as $studentTask) {
     // Screen out null timestamps
     $dueDate = $studentTask->DueDate ? date('m/d/Y', $studentTask->DueDate) : '';
     $expirationDate = $studentTask->ExpirationDate ? date('m/d/Y', $studentTask->ExpirationDate) : '';
+    $createdDate = $studentTask->Created ? date("m/d/Y", $studentTask->Created) : '';
 
     $most_recent_submission = $studentTask->getSubmissionTimestamp();
     $submittedDate = $most_recent_submission ? date('m/d/Y', $most_recent_submission) : '';
@@ -55,6 +56,7 @@ foreach ($studentTasks as $studentTask) {
         $studentTask->Student->StudentNumber,
         $studentTask->Task->Title,
         $studentTask->Task->Creator->getFullName(),
+        $createdDate,
         $studentTask->Section->Title,
         $studentTask->TaskStatus,
         $dueDate,
@@ -70,6 +72,7 @@ $headers = [
     'ID',
     'Task Name',
     'Teacher Assigned',
+    'Created',
     'Studio Name',
     'Current Status of task',
     'Due date',


### PR DESCRIPTION
- Add a method for getting evidence requirements by level
- Fix typo in competency details export script.
- Fix issue with competency details export related to competencies with no skills or demonstration requirements configured.
- Reduce memory usage in demonstrations export
- Return correct competency levels for task skills
- Set content area id correctly in SlateDemonstrationsStudent app
- Correctly fallback to session user when viewing SlateDemonstrationsStudent app
- Add created date column to tasks export
- Fix column and data alignment, remove 'Mapping' column, and show demonstrated date for demonstrations export
- Fix student filtering in demonstrations legacy export
- Sort student competencies by level in competencies details export
- Update completion logic to allow getting calculations by date range.
- Add ability to filter competencies-details, competencies, and content-area exports by date range
- Add basic UI for filtering export scripts