### PR TITLE
Add 'Rated' column to exports

### DIFF
--- a/site-root/cbl/exports/competencies-details.csv.php
+++ b/site-root/cbl/exports/competencies-details.csv.php
@@ -149,7 +149,7 @@ foreach ($students as $student) {
                         if ($demonstrationSkill->Override) {
                             $completedOpportunities = $demonstrationsRequired;
                             $missedOpportunities = 0;
-                        } else {
+                        } elseif ($demonstrationSkill->DemonstratedLevel > 0) {
                             $totalRatedOpportunities++;
                         }
 

--- a/site-root/cbl/exports/competencies-details.csv.php
+++ b/site-root/cbl/exports/competencies-details.csv.php
@@ -3,7 +3,7 @@
 $GLOBALS['Session']->requireAccountLevel('Staff');
 
 // This was causing a script timeout (30 seconds), this should help speed it up
-\Site::$debug = true;
+\Site::$debug = false;
 set_time_limit(0);
 
 $rows = [];
@@ -46,7 +46,7 @@ if ($from && $to) {
 }
 
 foreach ($students as $student) {
-    
+
     $demonstrationConditions = array_merge($defaultDemonstrationConditions, [
         'StudentID' => $student->ID
     ]);
@@ -59,7 +59,7 @@ foreach ($students as $student) {
             join(') AND (',\Slate\CBL\Demonstrations\Demonstration::mapConditions($demonstrationConditions))
         ]
     );
-    
+
 
     $studentCompetenciesByLevel = \DB::arrayTable(
         'Level',
@@ -99,7 +99,7 @@ foreach ($students as $student) {
 
             $completion = $competency->getCompletionForStudent($student, $level, $defaultDemonstrationConditions[0]);
             $totalER = $competency->getTotalDemonstrationsRequired($level);
-            
+
             // get all skills for this competency
             $skills = $competency->Skills;
             $skillsWithGrowth = 0;

--- a/site-root/cbl/exports/competencies-details.csv.php
+++ b/site-root/cbl/exports/competencies-details.csv.php
@@ -3,7 +3,7 @@
 $GLOBALS['Session']->requireAccountLevel('Staff');
 
 // This was causing a script timeout (30 seconds), this should help speed it up
-\Site::$debug = false;
+\Site::$debug = true;
 set_time_limit(0);
 
 $rows = [];
@@ -21,6 +21,7 @@ $headers = [
     'Total ER',
     'Total Opportunities',
     'Completed ER',
+    'Rated',
     'Missed ER'
 ];
 
@@ -45,6 +46,7 @@ if ($from && $to) {
 }
 
 foreach ($students as $student) {
+    
     $demonstrationConditions = array_merge($defaultDemonstrationConditions, [
         'StudentID' => $student->ID
     ]);
@@ -57,6 +59,7 @@ foreach ($students as $student) {
             join(') AND (',\Slate\CBL\Demonstrations\Demonstration::mapConditions($demonstrationConditions))
         ]
     );
+    
 
     $studentCompetenciesByLevel = \DB::arrayTable(
         'Level',
@@ -74,7 +77,6 @@ foreach ($students as $student) {
         ]
     );
 
-
     foreach ($studentCompetenciesByLevel as $level => $studentCompetencies) {
         foreach ($studentCompetencies as $studentCompetency) {
             // initialize variables for calculated fields
@@ -83,6 +85,7 @@ foreach ($students as $student) {
             $totalER = 0;
             $totalOpportunities = 0;
             $totalCompletedOpportunities = 0;
+            $totalRatedOpportunities = 0;
             $totalMissedOpportunities = 0;
             $competenciesWithGrowth = 0;
 
@@ -96,7 +99,7 @@ foreach ($students as $student) {
 
             $completion = $competency->getCompletionForStudent($student, $level, $defaultDemonstrationConditions[0]);
             $totalER = $competency->getTotalDemonstrationsRequired($level);
-
+            
             // get all skills for this competency
             $skills = $competency->Skills;
             $skillsWithGrowth = 0;
@@ -123,10 +126,9 @@ foreach ($students as $student) {
                         'order' => 'Created ASC'
                     ]);
 
-
                     $nonMissingDemonstrationSkills = [];
                     foreach ($demonstrationSkills as $demonstrationSkill) {
-                        $totalOpportunities += 1;
+                        $totalOpportunities++;
 
                         if ($demonstrationSkill->DemonstratedLevel > 0 && !$demonstrationSkill->Override) {
                             array_push($nonMissingDemonstrationSkills, $demonstrationSkill);
@@ -135,7 +137,7 @@ foreach ($students as $student) {
                         if ($demonstrationSkill->DemonstratedLevel > 0) {
                             $completedOpportunities += 1;
                         } else {
-                            $missedOpportunities += 1;
+                            $missedOpportunities++;
                         }
 
                         // no credit for logs beyond the number required
@@ -147,6 +149,8 @@ foreach ($students as $student) {
                         if ($demonstrationSkill->Override) {
                             $completedOpportunities = $demonstrationsRequired;
                             $missedOpportunities = 0;
+                        } else {
+                            $totalRatedOpportunities++;
                         }
 
                     }
@@ -175,13 +179,14 @@ foreach ($students as $student) {
                 $totalGrowth = $totalGrowth / $totalSkillsWithGrowth;
             }
 
-            $progress = 0;
             if ($totalER > 0) {
                 $progress = 100 * ($totalCompletedOpportunities / $totalER);
+            } else {
+                $progress = 100;
             }
 
             // add date to result
-            array_push($rows, [
+            $row = [
                 $student->ID,
                 $student->getFullName(),
                 $student->StudentNumber,
@@ -193,8 +198,10 @@ foreach ($students as $student) {
                 $totalER,
                 $totalOpportunities,
                 $totalCompletedOpportunities,
+                min($totalRatedOpportunities, $totalER),
                 $totalMissedOpportunities
-            ]);
+            ];
+            array_push($rows, $row);
         }
     }
 }

--- a/site-root/cbl/exports/content-areas.csv.php
+++ b/site-root/cbl/exports/content-areas.csv.php
@@ -177,10 +177,9 @@ foreach ($students as $student) {
                             if ($demonstrationSkill->Override) {
                                 $completedOpportunities = $demonstrationsRequired;
                                 $missedOpportunities = 0;
-                            } else {
+                            } elseif ($demonstrationSkill->DemonstratedLevel > 0) {
                                 $ratedOpportunities++;
                             }
-
                         }
 
                         $totalGrowth += $growth;

--- a/site-root/cbl/exports/content-areas.csv.php
+++ b/site-root/cbl/exports/content-areas.csv.php
@@ -20,6 +20,7 @@ $headers = [
     'Total ER',
     'Total Opportunities',
     'Completed ER',
+    'Rated',
     'Missed ER'
 ];
 
@@ -91,6 +92,7 @@ foreach ($students as $student) {
             $totalER = 0;
             $totalOpportunities = 0;
             $totalCompletedOpportunities = 0;
+            $totalRatedOpportunities = 0;
             $totalMissedOpportunities = 0;
             $totalGrowth = 0;
             $totalPerformanceLevel = 0;
@@ -124,6 +126,7 @@ foreach ($students as $student) {
                     $growth = 0;
                     $skillsWithGrowth = 0;
                     $completedOpportunities = 0;
+                    $ratedOpportunities = 0;
                     $missedOpportunities = 0;
                     $demonstrationsRequired = 0;
 
@@ -174,6 +177,8 @@ foreach ($students as $student) {
                             if ($demonstrationSkill->Override) {
                                 $completedOpportunities = $demonstrationsRequired;
                                 $missedOpportunities = 0;
+                            } else {
+                                $ratedOpportunities++;
                             }
 
                         }
@@ -182,6 +187,7 @@ foreach ($students as $student) {
                         $totalSkillsWithGrowth += $skillsWithGrowth;
                         $totalCompletedOpportunities += $completedOpportunities;
                         $totalMissedOpportunities += min($missedOpportunities, $demonstrationsRequired - $completedOpportunities);
+                        $totalRatedOpportunities += min($demonstrationsRequired, $ratedOpportunities);
                     }
 
                 }
@@ -213,6 +219,7 @@ foreach ($students as $student) {
                 $totalER,
                 $totalOpportunities,
                 $totalCompletedOpportunities,
+                $totalRatedOpportunities,
                 $totalMissedOpportunities
             ];
 


### PR DESCRIPTION
- Include 'Rated' column in `competencies_details` & `content_areas` CSV exports, which tallies the amount of rated skills (numerical, excluding `0` for Missing, and `O` for Overrides) were reviewed for a given competency/content area.