### PR TITLE
Fix issues with rating tasks

### DIFF
--- a/php-classes/Slate/CBL/Demonstrations/DemonstrationsRequestHandler.php
+++ b/php-classes/Slate/CBL/Demonstrations/DemonstrationsRequestHandler.php
@@ -116,14 +116,9 @@ class DemonstrationsRequestHandler extends \RecordsRequestHandler
                         ,'Override' => !empty($skill['Override'])
                     ], true);
                 } elseif ($existingSkills[$skill['SkillID']]['DemonstratedLevel'] != $skill['DemonstratedLevel']) {
-                    DB::nonQuery(
-                        'UPDATE `%s` SET DemonstratedLevel = "%s" WHERE ID = %u'
-                        ,[
-                            DemonstrationSkill::$tableName
-                            ,DB::escape($skill['DemonstratedLevel'])
-                            ,$existingSkills[$skill['SkillID']]['ID']
-                        ]
-                    );
+                    $DemoSkill = DemonstrationSkill::getByID($existingSkills[$skill['SkillID']]['ID']);
+                    $DemoSkill->DemonstratedLevel = $skill['DemonstratedLevel'];
+                    $DemoSkill->save(false);
                 }
             }
 

--- a/php-classes/Slate/CBL/Tasks/StudentTask.php
+++ b/php-classes/Slate/CBL/Tasks/StudentTask.php
@@ -151,7 +151,7 @@ class StudentTask extends \VersionedRecord
     {
         switch ($name) {
             case 'AllSkills':
-                return $this->Skills + ($this->Task ? $this->Task->Skills : []);
+                return array_merge($this->Skills, ($this->Task ? $this->Task->Skills : []));
 
             default:
                 return parent::getValue($name);

--- a/php-classes/Slate/CBL/Tasks/TeacherDashboardRequestHandler.php
+++ b/php-classes/Slate/CBL/Tasks/TeacherDashboardRequestHandler.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Slate\CBL\Tasks;
+
+class TeacherDashboardRequestHandler extends \RequestHandler
+{
+    public static $userResponseModes = [
+        'application/json' => 'json',
+        'text/csv' => 'csv'
+    ];
+    
+    public static function handleRequest()
+    {
+        $GLOBALS['Session']->requireAccountLevel('Staff');
+
+        switch ($action = static::shiftPath()) {
+            case '':
+            case false:
+                return static::handleDashboardRequest();
+            
+            case 'skill-completions':
+                return static::handleSkillCompletionsRequest();
+#            case 'completions':
+#                return static::handleCompletionsRequest();
+#            case 'demonstration-skills':
+#                return static::handleDemonstrationSkillsRequest();
+            default:
+                return static::throwNotFoundError();
+        }
+    }
+    
+    public static function handleDashboardRequest()
+    {
+        return Sencha_RequestHandler::respond('app/SlateTasksTeacher/ext', [
+            'App' => Sencha_App::getByName('SlateDemonstrationsTeacher'),
+            'mode' => 'production',
+            'ContentArea' => $ContentArea,
+            'students' => $students
+        ]);
+    }
+    
+    public static function handleSkillCompletionsRequest()
+    {
+        if (!$studentTaskId = $_REQUEST['studentTaskId']) {
+            return static::throwInvalidRequestError('studentTaskId must be supplied.');
+        } else if (!$StudentTask = StudentTask::getByID($studentTaskId)) {
+            return static::throwNotFoundError('Student task was not found.');
+        }
+        
+        $completions = [];
+        $indexedDemonstrationSkills = [];
+        
+        $demonstrationSkills = $StudentTask->Demonstration ? $StudentTask->Demonstration->Skills : [];
+        foreach ($demonstrationSkills as $DemonstrationSkill) {
+            $indexedDemonstrationSkills[$DemonstrationSkill->SkillID] = $DemonstrationSkill;
+        }
+        
+        foreach ($StudentTask->AllSkills as $Skill) {
+            $completions[] = array_merge($Skill->getDetails(['Competency']), [
+                'StudentID' => $StudentTask->StudentID,
+                'currentLevel' => array_key_exists($Skill->ID, $indexedDemonstrationSkills) ? $indexedDemonstrationSkills[$Skill->ID]->TargetLevel : $Skill->Competency->getCurrentLevelForStudent($StudentTask->Student)
+            ]);
+        }
+
+#        foreach ($StudentTask->AllSkills as $Skill) {
+#            if (!array_key_exists($Skill->Competency->Code, $groupedSkills)) {
+#                $groupedSkills[$Skill->Competency->Code] = [
+#                    'skills' => [],
+#                    'Code' => $Skill->Competency->Code,
+#                    'Descriptor' => $Skill->Competency->Descriptor,
+#                    'CompetencyLevel' => $Skill->Competency->getCurrentLevelForStudent($StudentTask->Student)
+#                ];
+#            }
+#            
+#            $skillData = $Skill->getDetails([]);
+#            $skillData['CompetencyLevel'] = !empty($demoSkillIds[$Skill->ID]) ? $demoSkillIds[$Skill->ID]->TargetLevel : $groupedSkills[$Skill->Competency->Code]['CompetencyLevel'];
+#            
+#            $groupedSkills[$Skill->Competency->Code]['skills'][] = $skillData;
+#        }
+        
+        return static::respond('studenttask-ratings', [
+            'skills' => $completions
+        ]);
+    }
+}

--- a/sencha-workspace/SlateTasksTeacher/app/controller/Dashboard.js
+++ b/sencha-workspace/SlateTasksTeacher/app/controller/Dashboard.js
@@ -33,8 +33,7 @@ Ext.define('SlateTasksTeacher.controller.Dashboard', {
         'Task@Slate.cbl.model',
         'StudentTask@Slate.cbl.model',
         'Comment@Slate.cbl.model.tasks',
-        'Demonstration@Slate.cbl.model',
-        'DemonstrationSkill@Slate.cbl.model'
+        'Demonstration@Slate.cbl.model'
     ],
 
 

--- a/sencha-workspace/SlateTasksTeacher/app/view/TaskRater.js
+++ b/sencha-workspace/SlateTasksTeacher/app/view/TaskRater.js
@@ -27,11 +27,9 @@ Ext.define('SlateTasksTeacher.view.TaskRater', {
     updateStudentTask: function(studentTask) {
         var me = this,
             form = me.down('slate-modalform'),
-            ratingsView = me.down('slate-ratingview'),
             commentsField = form.down('slate-commentsfield'),
             submissionsCmp = form.down('slate-tasks-submissions'),
-            skillsField = me.down('slate-skillsfield'),
-            groupedSkills = studentTask.getTaskSkillsGroupedByCompetency();
+            skillsField = me.down('slate-skillsfield');
 
         if (studentTask.get('DueDate')) {
             form.down('[name=DueDate]').setValue(studentTask.get('DueDate'));
@@ -44,10 +42,24 @@ Ext.define('SlateTasksTeacher.view.TaskRater', {
         commentsField.setRecord(studentTask);
         submissionsCmp.setData(studentTask.get('Submissions'));
         skillsField.setSkills(studentTask.get('Skills'), true, false); // appendSkills, editable
-        ratingsView.setData({
-            ratings: [7, 8, 9, 10, 11, 12, 'M'],
-            competencies: groupedSkills
-        });
+    },
+
+    updateDemonstration: function(demonstration) {
+        var me = this,
+            ratingView = me.down('slate-ratingview'),
+            saveRatingsBtn = me.down('#save-ratings-btn'),
+            resetRatingsBtn = me.down('#reset-ratings-btn');
+
+        if (demonstration) {
+            // load skills into rating view
+            ratingView.setConfig({
+                defaultRatings: demonstration.get('Skills'),
+                demonstrationSkills: demonstration.get('Skills')
+            });
+
+            resetRatingsBtn.show();
+            saveRatingsBtn.show();
+        }
     },
 
     updateReadOnly: function(readOnly) {

--- a/sencha-workspace/packages/slate-cbl/src/view/modals/RateTask.js
+++ b/sencha-workspace/packages/slate-cbl/src/view/modals/RateTask.js
@@ -14,7 +14,8 @@ Ext.define('Slate.cbl.view.modals.RateTask', {
 
     config: {
         task: null,
-        studentTask: null
+        studentTask: null,
+        demonstration: null
     },
 
     dockedItems: [
@@ -63,7 +64,7 @@ Ext.define('Slate.cbl.view.modals.RateTask', {
         }
     ],
 
-   items: [
+    items: [
         {
             xtype: 'slate-modalform',
             defaultType: 'displayfield',
@@ -115,6 +116,31 @@ Ext.define('Slate.cbl.view.modals.RateTask', {
                 },
                 {
                     xtype: 'slate-ratingview'
+                },
+                {
+                    xtype: 'fieldcontainer',
+                    defaults: {
+                        flex: 1
+                    },
+                    layout: 'hbox',
+                    items: [{
+                        xtype: 'button',
+                        itemId: 'reset-ratings-btn',
+                        action: 'resetratings',
+                        text: 'Reset',
+                        hidden: true,
+                        disabled: true
+                    }, {
+                        xtype: 'tbspacer',
+                        flex: 4
+                    }, {
+                        xtype: 'button',
+                        itemId: 'save-ratings-btn',
+                        action: 'saveratings',
+                        text: 'Save',
+                        hidden: true,
+                        disabled: true
+                    }]
                 },
                 {
                     xtype: 'slate-tasks-submissions'

--- a/sencha-workspace/packages/slate-cbl/src/widget/RatingView.js
+++ b/sencha-workspace/packages/slate-cbl/src/widget/RatingView.js
@@ -19,7 +19,7 @@ Ext.define('Slate.cbl.widget.RatingView', {
         demonstrationSkills: null,
         defaultRatings: null
     },
-    // todo: add ratings as config.
+
     tpl: [
         '{% this.ratings = values.ratings %}',
         '{% this.menuRatings = values.menuRatings %}',
@@ -94,7 +94,6 @@ Ext.define('Slate.cbl.widget.RatingView', {
                 if (rating === null || scope.menuRatings.indexOf(rating) > -1) {
                     cls += ' is-selected';
                 }
-                console.log(arguments);
                 return cls;
             },
 
@@ -203,8 +202,7 @@ Ext.define('Slate.cbl.widget.RatingView', {
     },
 
     applyDemonstrationSkills: function(demonstrationSkills) {
-        var me = this,
-            i = 0,
+        var i = 0,
             indexedDemonstrationSkills = {};
 
         for (; i < demonstrationSkills.length; i++) {

--- a/sencha-workspace/packages/slate-cbl/src/widget/RatingView.js
+++ b/sencha-workspace/packages/slate-cbl/src/widget/RatingView.js
@@ -254,7 +254,7 @@ Ext.define('Slate.cbl.widget.RatingView', {
         if (!me.getReadOnly()) {
             if (isRemoveEl) {
                 naRatingEl = target.parent('.slate-ratingview-skill').down('.slate-ratingview-rating-menu');
-                me.updateRatingEl(naRatingEl, 'N/A');
+                me.updateRatingEl(naRatingEl);
                 me.selectRating(naRatingEl, false);
             } else if (isRatingEl) {
                 me.selectRating(target);
@@ -266,7 +266,7 @@ Ext.define('Slate.cbl.widget.RatingView', {
         var me = this,
             skillEl = target.parent('.slate-ratingview-skill'),
 
-            rating = target.getAttribute('data-rating') || 'N/A',
+            rating = target.getAttribute('data-rating'),
             competency = skillEl.getAttribute('data-competency'),
             skillId = skillEl.getAttribute('data-skill-id'),
 
@@ -280,14 +280,15 @@ Ext.define('Slate.cbl.widget.RatingView', {
 
         // deselect other ratings
         ratingEls.removeCls('is-selected');
+        target.addCls('is-selected');
 
         if (rating == 'N/A') {
             naRating.addCls('slate-ratingview-rating-null');
+            rating = null;
         } else {
             naRating.removeCls('slate-ratingview-rating-null');
         }
 
-        target.addCls('is-selected');
 
         return me.fireEvent('rateskill', me, {
             rating: rating,

--- a/site-root/cbl/dashboards/tasks/teacher.php
+++ b/site-root/cbl/dashboards/tasks/teacher.php
@@ -1,8 +1,10 @@
 <?php
 
-$GLOBALS['Session']->requireAccountLevel('Staff');
-
-Sencha_RequestHandler::respond('app/SlateTasksTeacher/ext', [
-    'App' => Sencha_App::getByName('SlateTasksTeacher'),
-    'mode' => 'production'
-]);
+\Slate\CBL\Tasks\TeacherDashboardRequestHandler::handleRequest();
+#
+#$GLOBALS['Session']->requireAccountLevel('Staff');
+#
+#Sencha_RequestHandler::respond('app/SlateTasksTeacher/ext', [
+#    'App' => Sencha_App::getByName('SlateTasksTeacher'),
+#    'mode' => 'production'
+#]);

--- a/site-root/cbl/exports/content-areas.csv.php
+++ b/site-root/cbl/exports/content-areas.csv.php
@@ -201,7 +201,7 @@ foreach ($students as $student) {
                     $totalCompetencyGrowth += $totalGrowth / $totalSkillsWithGrowth;
                 }
 
-                if ($totalGrowth && $totalSkillsWithGrowth> 0) {
+                if ($totalSkillsWithGrowth> 0) {
                     $totalCompetenciesWithGrowth++;
                 }
 


### PR DESCRIPTION
- [x] Add buttons for saving and resetting unsaved ratings.
- [x] Save ratings in batch
- [x] Allow removal of ratings
- [x] Verify competency promotion when rating skills
- [x] Automatically graduate students in competencies when editing an existing rating, that previously prevented a promotion, due to the average level of skill logs being insufficient.