### PR TITLE
Release: slate-cbl v2.1.20

### DIFF
--- a/php-classes/Slate/CBL/Skill.php
+++ b/php-classes/Slate/CBL/Skill.php
@@ -19,7 +19,7 @@ class Skill extends \VersionedRecord
         ,'Code' => [
             'unique' => true
         ]
-        ,'Descriptor'
+        ,'Descriptor' => 'clob'
         ,'Statement' => 'clob'
         ,'DemonstrationsRequired' => 'json'
     ];
@@ -177,7 +177,7 @@ class Skill extends \VersionedRecord
 
         return $level;
     }
-    
+
     public function getDemonstrationsRequiredByLevel($level, $returnDefault = true)
     {
         if (isset($this->DemonstrationsRequired[$level])) {
@@ -185,7 +185,7 @@ class Skill extends \VersionedRecord
         } else if ($returnDefault) { // return default value if level is not explicitely set.$_COOKIE
             return $this->DemonstrationsRequired['default'];
         }
-        
+
         return null;
     }
 }

--- a/php-migrations/Slate/CBL/20170319_skill-descriptor-field-type.php
+++ b/php-migrations/Slate/CBL/20170319_skill-descriptor-field-type.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Slate\CBL;
+
+$newColumnType = 'TEXT';
+
+if (!static::tableExists(Skill::$tableName)) {
+    print('Skipping, table does not exist.');
+    return static::STATUS_SKIPPED;
+}
+
+if (static::getColumnType(Skill::$tableName, 'Descriptor') == $newColumnType) {
+    print('Skipping, column type already migrated.');
+    return static::STATUS_SKIPPED;
+}
+
+\DB::nonQuery("ALTER TABLE " . Skill::$tableName . " CHANGE COLUMN `Descriptor` `Descriptor` $newColumnType NOT NULL");
+
+return static::STATUS_EXECUTED;

--- a/php-migrations/Slate/CBL/20170319_skill-descriptor-field-type.php
+++ b/php-migrations/Slate/CBL/20170319_skill-descriptor-field-type.php
@@ -5,7 +5,7 @@ namespace Slate\CBL;
 $newColumnType = 'TEXT';
 
 if (!static::tableExists(Skill::$tableName)) {
-    print('Skipping, table does not exist.');
+    print('Skippingo table does not exist.');
     return static::STATUS_SKIPPED;
 }
 
@@ -15,5 +15,6 @@ if (static::getColumnType(Skill::$tableName, 'Descriptor') == $newColumnType) {
 }
 
 \DB::nonQuery("ALTER TABLE " . Skill::$tableName . " CHANGE COLUMN `Descriptor` `Descriptor` $newColumnType NOT NULL");
+\DB::nonQuery("ALTER TABLE " . Skill::$historyTable . " CHANGE COLUMN `Descriptor` `Descriptor` $newColumnType NOT NULL");
 
 return static::STATUS_EXECUTED;

--- a/site-root/cbl/import-maps.php
+++ b/site-root/cbl/import-maps.php
@@ -35,6 +35,7 @@ while ($mapsRow = $mapsCsv->getNextRow()) {
                     'default' => $row['ER']
                 ];
             } else { // handle comma-delimited level:values pairs: i.e 9:2,10:3,default:4
+                $demonstrationRequirements = [];
                 $splitERs = explode(',', $row['ER']);
                 foreach ($splitERs as $er) {
                     list($lvl, $total) = explode(':', $er);

--- a/site-root/cbl/import-maps.php
+++ b/site-root/cbl/import-maps.php
@@ -46,6 +46,10 @@ while ($mapsRow = $mapsCsv->getNextRow()) {
 
                     $demonstrationRequirements[$lvl] = $total;
                 }
+
+                if (!isset($demonstrationRequirements['default'])) {
+                    $demonstrationRequirements['default'] = 0;
+                }
             }
 
             \Debug::dumpVar(Slate\CBL\Skill::create([


### PR DESCRIPTION
- Update `\Slate\CBL\Skill`'s `Descriptor` column type to `TEXT` to allow for longer descriptions
    - Create migration script to migrate `Slate\CBL\Skill` table
- Fix CBL `import-maps` script 
    - Handle dynamic evidence requirement values
        - Backwards compatible
    - Set default evidence requirements value to 0, if left undefined.
