### PR TITLE
Release: slate-cbl v2.2.2

### DIFF
--- a/php-classes/Slate/CBL/StudentCompetency.php
+++ b/php-classes/Slate/CBL/StudentCompetency.php
@@ -14,6 +14,7 @@ class StudentCompetency extends \ActiveRecord
 {
     public static $autoGraduate = true;
     public static $isLevelComplete;
+    public static $minimumRatingOffset = null;
 
     // ActiveRecord configuration
     public static $tableName = 'cbl_student_competencies';
@@ -335,6 +336,19 @@ class StudentCompetency extends \ActiveRecord
         // Require minimum average as offset from level
         if ($minimumOffset !== null && $average < $this->Level + $minimumOffset) {
             return false;
+        }
+
+        // Require all demonstrations have ratings above minimum
+        if (static::$minimumRatingOffset !== null) {
+            $minRating = $this->Level - static::$minimumRatingOffset;
+
+            foreach ($this->getEffectiveDemonstrationsData() as $skillID => $demonstrations) {
+                foreach ($demonstrations as $demonstration) {
+                    if ($demonstration['DemonstratedLevel'] < $minRating) {
+                        return false;
+                    }
+                }
+            }
         }
 
         // Custom level complete function

--- a/php-classes/Slate/CBL/StudentCompetency.php
+++ b/php-classes/Slate/CBL/StudentCompetency.php
@@ -13,6 +13,7 @@ use Slate\CBL\Demonstrations\DemonstrationSkill;
 class StudentCompetency extends \ActiveRecord
 {
     public static $autoGraduate = true;
+    public static $isLevelComplete;
 
     // ActiveRecord configuration
     public static $tableName = 'cbl_student_competencies';
@@ -326,13 +327,22 @@ class StudentCompetency extends \ActiveRecord
         $competencyEvidenceRequirements = $this->Competency->getTotalDemonstrationsRequired($this->Level);
         $minimumOffset = $this->Competency->getMinimumAverageOffset();
 
-        return (
-            $completed >= $competencyEvidenceRequirements &&
-            (
-                $logged === 0 ||
-                $average >= ($this->Level + $minimumOffset)
-            )
-        );
+        // Require a minimum total demonstrations for the competency
+        if ($competencyEvidenceRequirements && $completed < $competencyEvidenceRequirements) {
+            return false;
+        }
+
+        // Require minimum average as offset from level
+        if ($minimumOffset !== null && $average < $this->Level + $minimumOffset) {
+            return false;
+        }
+
+        // Custom level complete function
+        if (is_callable(static::$isLevelComplete)) {
+            return call_user_func(static::$isLevelComplete, $this);
+        }
+
+        return true;
     }
 
     private $competencyGrowth;

--- a/php-classes/Slate/CBL/StudentCompetency.php
+++ b/php-classes/Slate/CBL/StudentCompetency.php
@@ -340,11 +340,11 @@ class StudentCompetency extends \ActiveRecord
 
         // Require all demonstrations have ratings above minimum
         if (static::$minimumRatingOffset !== null) {
-            $minRating = $this->Level - static::$minimumRatingOffset;
+            $minimumRating = $this->Level - static::$minimumRatingOffset;
 
             foreach ($this->getEffectiveDemonstrationsData() as $skillID => $demonstrations) {
                 foreach ($demonstrations as $demonstration) {
-                    if ($demonstration['DemonstratedLevel'] < $minRating) {
+                    if ($demonstration['DemonstratedLevel'] < $minimumRating) {
                         return false;
                     }
                 }

--- a/php-classes/Slate/CBL/StudentCompetency.php
+++ b/php-classes/Slate/CBL/StudentCompetency.php
@@ -14,7 +14,7 @@ class StudentCompetency extends \ActiveRecord
 {
     public static $autoGraduate = true;
     public static $isLevelComplete;
-    public static $minimumRatingOffset = null;
+    public static $minimumRatingOffset;
 
     // ActiveRecord configuration
     public static $tableName = 'cbl_student_competencies';

--- a/sencha-workspace/SlateTasksStudent/app/view/AppHeader.js
+++ b/sencha-workspace/SlateTasksStudent/app/view/AppHeader.js
@@ -26,12 +26,15 @@ Ext.define('SlateTasksStudent.view.AppHeader', {
         },
         {
             xtype: 'tbfill'
-        },
-        {
-            xtype: 'button',
-            iconCls: 'x-fa fa-clock-o',
-            enableToggle: true,
-            action: 'show-recent'
+
+        // @todo Unide recent activity toggle once the RecentActivity.js
+        // view is populated with real data.
+        // },
+        // {
+        //     xtype: 'button',
+        //     iconCls: 'x-fa fa-clock-o',
+        //     enableToggle: true,
+        //     action: 'show-recent'
         }]
     }]
 

--- a/sencha-workspace/SlateTasksStudent/app/view/Dashboard.js
+++ b/sencha-workspace/SlateTasksStudent/app/view/Dashboard.js
@@ -38,10 +38,11 @@ Ext.define('SlateTasksStudent.view.Dashboard', {
                             flex: 1
                         }
                     ]
-                },
-                {
-                    xtype: 'slate-taskhistory',
-                    margin: '32 0 0'
+                // @todo Unhide task history once it can be populated with live data
+                // },
+                // {
+                //     xtype: 'slate-taskhistory',
+                //     margin: '32 0 0'
                 }
             ]
         }


### PR DESCRIPTION
- Hide mock UI components for activity feed and task history
- Add configurable `$isLevelComplete` function for custom auto-graduation requirements
- Add configurable `$minimumRatingOffset` for requiring all effective skill demonstration ratings be greater than a given offset from the current level before auto-graduation