### PR TITLE
Release: slate-cbl v2.2.3

### DIFF
--- a/html-templates/cbl/student-competencies/studentCompetencies.tpl
+++ b/html-templates/cbl/student-competencies/studentCompetencies.tpl
@@ -1,0 +1,90 @@
+{extends "designs/site.tpl"}
+
+{block "title"}Student Competencies &middot; {$dwoo.parent}{/block}
+
+{block "content"}
+    {load_templates "subtemplates/paging.tpl"}
+
+    <header class="page-header">
+        <h2 class="header-title">Student Competencies</h2>
+
+        <div class="page-buttons">
+            <span class="button-group">
+                <label class="muted">Download all results:&nbsp;</label>
+                <a class="button small" href="?{refill_query format=json limit=0 offset=0}">JSON</a>
+                <a class="button small" href="?{refill_query format=csv limit=0 offset=0}">CSV</a>
+            </span>
+        </div>
+    </header>
+
+    <form class="filter-list">
+        <fieldset class="inline-fields">
+            <h4 class="section-title">Filters</h4>
+
+            {field
+                inputName=student
+                default=$.get.student
+                label='Student'
+                placeholder='jdoe'
+            }
+
+            {field
+                inputName=competency
+                default=$.get.competency
+                label='Competency'
+                placeholder='ABC.2'
+            }
+
+            {selectField
+                inputName=level
+                default=$.get.level
+                label='Level'
+                options=DB::allValues('Level', 'SELECT DISTINCT Level FROM cbl_student_competencies ORDER BY Level')
+                useKeyAsValue=no
+                blankOption='Any'
+            }
+
+            {selectField
+                inputName=entered-via
+                default=$.get.entered-via
+                label='Entered Via'
+                options=Slate\CBL\StudentCompetency::getFieldOptions(EnteredVia, values)
+                useKeyAsValue=no
+                blankOption='Any'
+            }
+
+            <div class="submit-area">
+                <input type="submit" value="Apply Filters">
+                <a href="{Slate\CBL\StudentCompetency::$collectionRoute}" class="button">Reset Filters</a>
+            </div>
+        </fieldset>
+    </form>
+
+
+    <table class="auto-width row-stripes row-highlight">
+        <thead>
+            <tr>
+                <th scope="col">ID</th>
+                <th scope="col">Student</th>
+                <th scope="col">Competency</th>
+                <th scope="col">Level</th>
+                <th scope="col">Entered Via</th>
+                <th scope="col">Baseline Rating</th>
+            </tr>
+        </thead>
+        <tbody>
+        {foreach item=StudentCompetency from=$data}
+            <tr>
+                <td><a href="{$StudentCompetency->getUrl()|escape}">#{$StudentCompetency->ID}</td>
+                <td>{contextLink $StudentCompetency->Student}</td>
+                <td>{contextLink $StudentCompetency->Competency}</td>
+                <td>{$StudentCompetency->Level}</td>
+                <td>{$StudentCompetency->EnteredVia|escape}</td>
+                <td>{$StudentCompetency->BaselineRating|escape|default:'&mdash;'}</td>
+            </tr>
+        {/foreach}
+        </tbody>
+    </table>
+
+    {pagingArrows count($data) $total $limit $offset}
+{/block}

--- a/html-templates/cbl/student-competencies/studentCompetency.tpl
+++ b/html-templates/cbl/student-competencies/studentCompetency.tpl
@@ -1,0 +1,76 @@
+{extends designs/site.tpl}
+
+{block title}{$data->getTitle()} &middot; {$dwoo.parent}{/block}
+
+{block content}
+    {load_templates subtemplates/dli.tpl}
+
+    <header class="page-header">
+        <h2 class="header-title">{contextLink $data}</h2>
+    </header>
+
+    <dl class="align-right compact">
+        {dli label=ID value=$data->ID}
+        {dli label=Created value=$data->Created|date_format}
+        {dli label=Creator value=$data->Creator->getTitle() url=$data->Creator->getUrl()}
+        {dli label=Student value=$data->Student->getTitle() url=$data->Student->getUrl()}
+        {dli label=Competency value=$data->Competency->getTitle() url=$data->Competency->getUrl()}
+        {dli label='Content Area' value=$data->Competency->ContentArea->getTitle() url=$data->Competency->ContentArea->getUrl()}
+        {dli label=Level value=$data->Level}
+        {dli label='Entered Via' value=$data->EnteredVia}
+        {dli label='Baseline Rating' value=$data->BaselineRating}
+        {dli label='Is Level Complete?' value=tif($data->isLevelComplete(), 'Yes', 'No')}
+        {dli label='Growth' value=$data->getGrowth()|number_format:2}
+        {dli label='Demonstrations Average' value=$data->getDemonstrationsAverage()|number_format:2}
+        {dli label='Demonstrations Logged' value=$data->getDemonstrationsLogged()|number_format}
+        {dli label='Demonstrations Missed' value=$data->getDemonstrationsMissed()|number_format}
+        {dli label='Demonstrations Complete' value=$data->getDemonstrationsComplete()|number_format}
+        {dli label='Demonstrations Required' value=$data->getDemonstrationsRequired()|number_format}
+    </dl>
+
+    <?php
+        $this->scope['effectiveDemonstrationSkillIds'] = [];
+
+        foreach ($this->scope['data']->getEffectiveDemonstrationsData() as $demonstrationSkills) {
+            foreach ($demonstrationSkills as $demonstrationSkill) {
+                $this->scope['effectiveDemonstrationSkillIds'][] = $demonstrationSkill['ID'];
+            }
+        }
+    ?>
+
+    <h3>Skill Demonstrations</h3>
+    <table class="auto-width row-stripes row-highlight">
+        <thead>
+            <tr>
+                <th scope="col">ID</th>
+                <th scope="col">Created</th>
+                <th scope="col">Creator</th>
+                <th scope="col">Demonstration</th>
+                <th scope="col">DemonstrationDate</th>
+                <th scope="col">Level</th>
+                <th scope="col">Rating</th>
+                <th scope="col">Override</th>
+            </tr>
+        </thead>
+        <tbody>
+        {foreach item=demonstrationSkills key=skillId from=$data->getDemonstrationData()}
+            <tr>
+                <th colspan="8">{contextLink Slate\CBL\Skill::getById($skillId)}</th>
+            </tr>
+            {foreach item=DemonstrationSkill from=$demonstrationSkills}
+                {$Demonstration = Slate\CBL\Demonstrations\Demonstration::getById($DemonstrationSkill.DemonstrationID)}
+                <tr class="{tif $DemonstrationSkill.ID|in_array:$effectiveDemonstrationSkillIds ? effective : muted}">
+                    <td>#{$DemonstrationSkill.ID}</td>
+                    <td>{$DemonstrationSkill.Created|date_format}</td>
+                    <td>{contextLink Emergence\People\Person::getById($DemonstrationSkill.CreatorID)}</td>
+                    <td><a href="{$Demonstration->getUrl()|escape}">#{$Demonstration->ID}</a></td>
+                    <td>{$DemonstrationSkill.DemonstrationDate|date_format}</td>
+                    <td>{$DemonstrationSkill.TargetLevel}</td>
+                    <td>{tif $DemonstrationSkill.DemonstratedLevel == '0' ? 'M' : $DemonstrationSkill.DemonstratedLevel}</td>
+                    <td>{tif($DemonstrationSkill.Override, 'Yes', 'No')}</td>
+                </tr>
+            {/foreach}
+        {/foreach}
+        </tbody>
+    </table>
+{/block}

--- a/php-classes/Google/DriveFile.php
+++ b/php-classes/Google/DriveFile.php
@@ -69,11 +69,7 @@ class DriveFile extends \ActiveRecord
 
     public static function __classLoaded()
     {
-        if (empty(API::$domain)) {
-            throw new Exception('Domain must be configured first');
-        }
-
-        if (empty(static::$validators['OwnerEmail']['domain'])) {
+        if (API::$domain && empty(static::$validators['OwnerEmail']['domain'])) {
             static::$validators['OwnerEmail']['domain'] = API::$domain;
         }
     }

--- a/php-classes/Slate/CBL/Competency.php
+++ b/php-classes/Slate/CBL/Competency.php
@@ -68,6 +68,17 @@ class Competency extends \VersionedRecord
         return $this->Code;
     }
 
+    public function getTitle()
+    {
+        $title = $this->Code;
+
+        if ($this->Descriptor) {
+            $title .= ': ' . $this->Descriptor;
+        }
+
+        return $title;
+    }
+
     public static function getByHandle($handle)
     {
         return static::getByCode($handle);

--- a/php-classes/Slate/CBL/ContentArea.php
+++ b/php-classes/Slate/CBL/ContentArea.php
@@ -43,6 +43,17 @@ class ContentArea extends \ActiveRecord
         return $this->Code;
     }
 
+    public function getTitle()
+    {
+        $title = $this->Code;
+
+        if ($this->Title) {
+            $title .= ': ' . $this->Title;
+        }
+
+        return $title;
+    }
+
     public static function getByHandle($handle)
     {
         return static::getByCode($handle);

--- a/php-classes/Slate/CBL/Demonstrations/DemonstrationSkill.php
+++ b/php-classes/Slate/CBL/Demonstrations/DemonstrationSkill.php
@@ -16,7 +16,6 @@ class DemonstrationSkill extends \ActiveRecord
     public static $fields = [
         'DemonstrationID' => [
             'type' => 'uint'
-            ,'index' => true
         ],
         'SkillID' => [
             'type' => 'uint'
@@ -33,6 +32,13 @@ class DemonstrationSkill extends \ActiveRecord
         'Override' => [
             'type' => 'boolean',
             'default' => false
+        ]
+    ];
+
+    public static $indexes = [
+        'DemonstrationSkill' => [
+            'fields' => ['DemonstrationID', 'SkillID'],
+            'unique' => true
         ]
     ];
 

--- a/php-classes/Slate/CBL/Skill.php
+++ b/php-classes/Slate/CBL/Skill.php
@@ -89,6 +89,17 @@ class Skill extends \VersionedRecord
         return $this->Code;
     }
 
+    public function getTitle()
+    {
+        $title = $this->Code;
+
+        if ($this->Descriptor) {
+            $title .= ': ' . $this->Descriptor;
+        }
+
+        return $title;
+    }
+
     public static function getByHandle($handle)
     {
         return static::getByCode($handle);

--- a/php-classes/Slate/CBL/StudentCompetenciesRequestHandler.php
+++ b/php-classes/Slate/CBL/StudentCompetenciesRequestHandler.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Slate\CBL;
+
+use ActiveRecord, RecordsRequestHandler;
+use Emergence\People\PeopleRequestHandler;
+
+
+class StudentCompetenciesRequestHandler extends RecordsRequestHandler
+{
+    public static $recordClass = StudentCompetency::class;
+    public static $accountLevelAPI = 'User';
+    public static $accountLevelBrowse = 'User';
+    public static $accountLevelRead = 'Staff';
+    public static $accountLevelComment = 'Staff';
+    public static $accountLevelWrite = 'Administrator';
+    public static $browseLimitDefault = 100;
+    public static $browseOrder = ['ID' => 'DESC'];
+
+
+    public static function checkReadAccess(ActiveRecord $Record, $suppressLogin = false)
+    {
+        $User = $GLOBALS['Session']->Person;
+
+        if (!$suppressLogin) {
+            $GLOBALS['Session']->requireAuthentication();
+        } elseif (!$User) {
+            return false;
+        }
+
+        if ($User->hasAccountLevel(static::$accountLevelRead)) {
+            return true;
+        }
+
+        return $Record->StudentID === $User->ID;
+    }
+
+    public static function handleBrowseRequest($options = [], $conditions = [], $responseID = null, $responseData = [])
+    {
+        $User = $GLOBALS['Session']->Person;
+
+        if (!$User || !$User->hasAccountLevel('Staff')) {
+            $conditions['StudentID'] = $User->ID;
+        }
+
+        // apply student filter
+        if (!$User) {
+            return static::throwUnauthorizedError('Login required');
+        } elseif (!empty($_GET['student'])) {
+            if (!$Student = PeopleRequestHandler::getRecordByHandle($_GET['student'])) {
+                return static::throwNotFoundError('Student not found');
+            }
+
+            if (!$User || ($Student->ID != $User->ID && !$User->hasAccountLevel('Staff'))) {
+                return static::throwUnauthorizedError('Only staff may browse others\' records');
+            }
+
+            $conditions['StudentID'] = $Student->ID;
+            $responseData['Student'] = $Student;
+        } elseif (!$User->hasAccountLevel('Staff')) {
+            $conditions['StudentID'] = $User->ID;
+            $responseData['Student'] = $User;
+        }
+
+
+        // apply competency filter
+        if (!empty($_GET['competency'])) {
+            if (!$Competency = CompetenciesRequestHandler::getRecordByHandle($_GET['competency'])) {
+                return static::throwNotFoundError('Competency not found');
+            }
+
+            $conditions['CompetencyID'] = $Competency->ID;
+            $responseData['Competency'] = $Competency;
+        }
+
+
+        // apply competency filter
+        if (!empty($_GET['level'])) {
+            if (!ctype_digit($_GET['level'])) {
+                return static::throwInvalidRequestError('Level must be numeric');
+            }
+
+            $conditions['Level'] = $_GET['level'];
+        }
+
+
+        // apply competency filter
+        if (!empty($_GET['entered-via'])) {
+            if (!in_array($_GET['entered-via'], StudentCompetency::getFieldOptions('EnteredVia', 'values'))) {
+                return static::throwInvalidRequestError('Entered Via must be numeric');
+            }
+
+            $conditions['EnteredVia'] = $_GET['entered-via'];
+        }
+
+        return parent::handleBrowseRequest($options, $conditions, $responseID, $responseData);
+    }  
+}

--- a/php-classes/Slate/CBL/StudentCompetency.php
+++ b/php-classes/Slate/CBL/StudentCompetency.php
@@ -340,7 +340,7 @@ class StudentCompetency extends \ActiveRecord
 
         // Require all demonstrations have ratings above minimum
         if (static::$minimumRatingOffset !== null) {
-            $minimumRating = $this->Level - static::$minimumRatingOffset;
+            $minimumRating = $this->Level + static::$minimumRatingOffset;
 
             foreach ($this->getEffectiveDemonstrationsData() as $skillID => $demonstrations) {
                 foreach ($demonstrations as $demonstration) {

--- a/php-classes/Slate/CBL/StudentCompetency.php
+++ b/php-classes/Slate/CBL/StudentCompetency.php
@@ -388,7 +388,7 @@ class StudentCompetency extends \ActiveRecord
 
             $totalGrowthSkills = count($growthData);
 
-            if ($totalGrowthSkills * 2 >= $this->Competency->getTotalSkills()) {
+            if ($totalGrowthSkills && $totalGrowthSkills * 2 >= $this->Competency->getTotalSkills()) {
                 $this->competencyGrowth = array_sum($growthData) / $totalGrowthSkills;
             } else {
                 $this->competencyGrowth = false;

--- a/php-classes/Slate/CBL/Tasks/StudentTask.php
+++ b/php-classes/Slate/CBL/Tasks/StudentTask.php
@@ -191,13 +191,14 @@ class StudentTask extends \VersionedRecord
         if ($this->Task && $this->Task->Skills) {
             foreach ($this->Task->Skills as $skill) {
                 $StudentCompetency = StudentCompetency::getCurrentForStudent($this->Student, $skill->Competency);
-                $demoSkillRating = $demoSkillIds[$skill->ID] ? $demoSkillIds[$skill->ID]->DemonstratedLevel : null;
+                $DemonstrationSkill = $demoSkillIds[$skill->ID];
 
                 $taskSkills[] = array_merge($skill->getData(), [
                     'CompetencyLevel' => $StudentCompetency ? $StudentCompetency->Level : null,
                     'CompetencyCode' => $skill->Competency ? $skill->Competency->Code : null,
                     'CompetencyDescriptor' => $skill->Competency ? $skill->Competency->Descriptor : null,
-                    'Rating' => $demoSkillRating
+                    'Rating' => $DemonstrationSkill ? $DemonstrationSkill->DemonstratedLevel : null,
+                    'Level' => $DemonstrationSkill ? $DemonstrationSkill->TargetLevel : null
                 ]);
             }
         }
@@ -205,13 +206,14 @@ class StudentTask extends \VersionedRecord
         if ($this->Skills) {
             foreach ($this->Skills as $skill) {
                 $StudentCompetency = StudentCompetency::getCurrentForStudent($this->Student, $skill->Competency);
-                $demoSkillRating = $demoSkillIds[$skill->ID] ? $demoSkillIds[$skill->ID]->DemonstratedLevel : null;
+                $DemonstrationSkill = $demoSkillIds[$skill->ID];
 
                 $taskSkills[] = array_merge($skill->getData(), [
                     'CompetencyLevel' => $StudentCompetency ? $StudentCompetency->Level : null,
                     'CompetencyCode' => $skill->Competency ? $skill->Competency->Code : null,
                     'CompetencyDescriptor' => $skill->Competency ? $skill->Competency->Descriptor : null,
-                    'Rating' => $demoSkillRating
+                    'Rating' => $DemonstrationSkill ? $DemonstrationSkill->DemonstratedLevel : null,
+                    'Level' => $DemonstrationSkill ? $DemonstrationSkill->TargetLevel : null
                 ]);
             }
         }

--- a/php-classes/Slate/CBL/Tasks/StudentTasksRequestHandler.php
+++ b/php-classes/Slate/CBL/Tasks/StudentTasksRequestHandler.php
@@ -92,25 +92,25 @@ class StudentTasksRequestHandler extends \RecordsRequestHandler
 
         $Demonstration = $StudentTask->getDemonstration();
 
-        $demoSkill = DemonstrationSkill::getByWhere([
+        $DemonstrationSkill = DemonstrationSkill::getByWhere([
             'DemonstrationID' => $Demonstration->ID,
             'SkillID' => $Skill->ID
         ]);
 
-        if (!$demoSkill) {
-            $demoSkill = DemonstrationSkill::create([
+        if (!$DemonstrationSkill) {
+            $DemonstrationSkill = DemonstrationSkill::create([
                 'DemonstrationID' => $Demonstration->ID,
                 'SkillID' => $Skill->ID,
                 'TargetLevel' => $StudentCompetency->Level
             ]);
         }
 
-        $demoSkill->DemonstratedLevel = $requestData['Rating'];
-        $demoSkill->save(false);
+        $DemonstrationSkill->DemonstratedLevel = $requestData['Rating'];
+        $DemonstrationSkill->save(false);
 
         return static::respond('studenttask/ratings', [
             'success' => true,
-            'data' => $demoSkill,
+            'data' => $DemonstrationSkill,
             'StudentTask' => $StudentTask
         ]);
     }

--- a/php-classes/Slate/CBL/Tasks/StudentTasksRequestHandler.php
+++ b/php-classes/Slate/CBL/Tasks/StudentTasksRequestHandler.php
@@ -108,7 +108,7 @@ class StudentTasksRequestHandler extends \RecordsRequestHandler
         $DemonstrationSkill->DemonstratedLevel = $requestData['Rating'];
         $DemonstrationSkill->save(false);
 
-        return static::respond('studenttask/ratings', [
+        return static::respond('ratingUpdated', [
             'success' => true,
             'data' => $DemonstrationSkill,
             'StudentTask' => $StudentTask
@@ -162,7 +162,7 @@ class StudentTasksRequestHandler extends \RecordsRequestHandler
         $StudentTaskSubmission->StudentTaskID = $StudentTask->ID;
         $StudentTaskSubmission->save();
 
-        return static::respond('studenttask/submit', [
+        return static::respond('submitted', [
             'data' => $StudentTask,
             'success' => true,
         ]);

--- a/php-classes/Slate/CBL/Tasks/StudentTasksRequestHandler.php
+++ b/php-classes/Slate/CBL/Tasks/StudentTasksRequestHandler.php
@@ -94,11 +94,10 @@ class StudentTasksRequestHandler extends \RecordsRequestHandler
 
         $demoSkill = DemonstrationSkill::getByWhere([
             'DemonstrationID' => $Demonstration->ID,
-            'SkillID' => $Skill->ID,
-            'TargetLevel' => $competencyLevel
+            'SkillID' => $Skill->ID
         ]);
 
-        if (!demoSkill) {
+        if (!$demoSkill) {
             $demoSkill = DemonstrationSkill::create([
                 'DemonstrationID' => $Demonstration->ID,
                 'SkillID' => $Skill->ID,

--- a/php-config/Git.config.d/slate-cbl.php
+++ b/php-config/Git.config.d/slate-cbl.php
@@ -26,6 +26,7 @@ Git::$repositories['slate-cbl'] = [
         'php-classes/Slate/CBL',
         'php-config/Git.config.d/slate-cbl.php',
         'php-config/Slate/UI/Tools.config.d/cbl.php',
+        'php-config/Slate/UI/UserProfile.config.d/cbl.php',
         'php-migrations/Slate/CBL',
         'sencha-workspace/packages/slate-cbl',
         'sencha-workspace/SlateDemonstrationsStudent',

--- a/php-config/Slate/UI/UserProfile.config.d/cbl.php
+++ b/php-config/Slate/UI/UserProfile.config.d/cbl.php
@@ -1,0 +1,20 @@
+<?php
+
+Slate\UI\UserProfile::$sources[] = function (Emergence\People\Person $Person) {
+    $links = [];
+
+    if ($Person->isA(Slate\People\Student::class)) {
+        $studentQuery = http_build_query([
+            'student' => $Person->Username
+        ]);
+
+        $links['Student Dashboards'] = [
+            'Competencies Dashboard' => '/cbl/dashboards/demonstrations/student?' . $studentQuery,
+            'Tasks Dashboard' => '/cbl/dashboards/tasks/student?' . $studentQuery
+        ];
+    }
+
+    return [
+        'Competency-Based Learning' => $links
+    ];
+};

--- a/php-migrations/Slate/CBL/2015041000000_demonstrated.php
+++ b/php-migrations/Slate/CBL/2015041000000_demonstrated.php
@@ -15,7 +15,7 @@ if (!static::tableExists(Demonstration::$tableName)) {
 // migration
 if (static::getColumnType(Demonstration::$tableName, 'Demonstrated') != $newDemonstratedType) {
     print("Updating `Demonstrated` column type\n");
-    \DB::nonQuery("ALTER TABLE " . Demonstration::$tableName . " CHANGE COLUMN `Demonstrated` `Demonstrated` $newDemonstratedType NOT NULL");
+    \DB::nonQuery("ALTER TABLE " . Demonstration::$tableName . " CHANGE COLUMN `Demonstrated` `Demonstrated` $newDemonstratedType `Demonstrated` NULL default NULL");
     $skipped = false;
 }
 

--- a/php-migrations/Slate/CBL/20161012000000_evidence-requirements.php
+++ b/php-migrations/Slate/CBL/20161012000000_evidence-requirements.php
@@ -4,7 +4,7 @@ namespace Slate\CBL;
 
 use DB;
 
-$newColumnType = 'JSON';
+$newColumnType = 'json';
 $newColumnDefinition = $newColumnType . ' NOT NULL';
 
 $originalColumnName = 'DemonstrationsRequired';

--- a/php-migrations/Slate/CBL/Demonstrations/20171018_unique-demonstration-skills.php
+++ b/php-migrations/Slate/CBL/Demonstrations/20171018_unique-demonstration-skills.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Slate\CBL\Demonstrations;
+use DB;
+
+
+$tableName = DemonstrationSkill::$tableName;
+$constraintName = 'DemonstrationSkill';
+
+
+// skip conditions
+if (!static::tableExists($tableName)) {
+    printf("Skipping migration because table `%s` does not exist yet\n", $tableName);
+    return static::STATUS_SKIPPED;
+}
+
+if (static::getConstraint($tableName, $constraintName)) {
+    printf("Skipping migration because constraint `%s` already exists\n", $constraintName);
+    return static::STATUS_SKIPPED;
+}
+
+
+// find duplicate values
+$duplicatePairs = DB::allRecords(
+    'SELECT DemonstrationID, SkillID, COUNT(*) AS Total, MAX(Created) AS LastCreated, MAX(ID) AS LastID FROM `%s` GROUP BY DemonstrationID, SkillID HAVING Total > 1 ORDER BY LastID',
+    [
+        $tableName
+    ]
+);
+
+printf("Found %u sets of duplicate DemonstrationID+SkillID values\n\n", count($duplicatePairs));
+
+foreach ($duplicatePairs as $pair) {
+    printf("Found duplicate: DemonstrationID=%u + SkillID=%u last updated %s\n", $pair['DemonstrationID'], $pair['SkillID'], $pair['LastCreated']);
+
+    $records = DB::allRecords('SELECT * FROM `%s` WHERE DemonstrationID = %u AND SkillID = %u ORDER BY ID', [
+        $tableName,
+        $pair['DemonstrationID'],
+        $pair['SkillID']
+    ]);
+
+    $firstID = null;
+    $duplicateIDs = [];
+    $lastRating = null;
+
+    foreach ($records as $record) {
+        if ($firstID) {
+            $duplicateIDs[] = $record['ID'];
+        } else {
+            $firstID = $record['ID'];
+        }
+
+        $lastRating = $record['DemonstratedLevel'];
+
+        printf("\tLevel=%02u\tRating=%02u\tID=%u\tCreated=%s\n", $record['TargetLevel'], $record['DemonstratedLevel'], $record['ID'], $record['Created']);
+    }
+
+    printf("\n\tSetting Rating=%u where ID=%u, deleting %s\n\n", $lastRating, $firstID, implode(', ', $duplicateIDs));
+
+    DB::nonQuery('UPDATE `%s` SET DemonstratedLevel = %u WHERE ID = %u', [$tableName, $lastRating, $firstID]);
+    DB::nonQuery('DELETE FROM `%s` WHERE ID IN (%s)', [$tableName, implode(',', $duplicateIDs)]);
+}
+
+print("Finished resolving duplicates\n");
+
+
+// drop solo index on DemonstrationID
+$demonstrationIdColumn = static::getColumn($tableName, 'DemonstrationID');
+
+if ($demonstrationIdColumn['COLUMN_KEY'] == 'MUL') {
+    printf("Updating table `%s`, dropping index on DemonstrationID\n", $tableName);
+    DB::nonQuery('ALTER TABLE `%s` DROP INDEX `DemonstrationID`', $tableName);
+}
+
+
+// add unique key on (DemonstrationID, SkillID)
+if (!static::getConstraint($tableName, $constraintName)) {
+    printf("Updating table `%s`, adding unique constraint `%s`\n", $tableName, $constraintName);
+    DB::nonQuery('ALTER TABLE `%s` ADD UNIQUE INDEX `%s` (DemonstrationID, SkillID)', [$tableName, $constraintName]);
+}
+
+
+// done
+return static::STATUS_EXECUTED;

--- a/sencha-workspace/SlateTasksStudent/app/model/StudentTask.js
+++ b/sencha-workspace/SlateTasksStudent/app/model/StudentTask.js
@@ -1,3 +1,4 @@
+// TODO: merge with Slate.cbl.model.StudentTask ?
 Ext.define('SlateTasksStudent.model.StudentTask', {
     extend: 'Ext.data.Model',
     requires: [

--- a/sencha-workspace/SlateTasksTeacher/app/controller/Dashboard.js
+++ b/sencha-workspace/SlateTasksTeacher/app/controller/Dashboard.js
@@ -371,25 +371,21 @@ Ext.define('SlateTasksTeacher.controller.Dashboard', {
 
     onRateSkillClick: function(ratingView, ratingData) {
         var me = this,
-            taskRater = me.getTaskRater(),
-            studentTask = taskRater.getStudentTask();
+            studentTask = me.getTaskRater().getStudentTask();
 
         Slate.API.request({
             url: studentTask.toUrl() + '/rate',
             method: 'POST',
             params: {
+                include: me.getStudentTasksStore().getProxy().getInclude()
+            },
+            jsonData: {
                 SkillID: ratingData.SkillID,
                 Rating: ratingData.Rating,
             },
-            callback: function(opts, success, response) {
-                // var record = response.data.record;
-
+            callback: function(options, success, response) {
                 if (success && response.data && response.data.success) {
-                    me.getStudentTasksStore().load({
-                        id: studentTask.getId(),
-                        addRecords: true
-                    });
-                    // studentTask.set(record);
+                    studentTask.set(response.data.StudentTask, { dirty: false });
                 } else {
                     Ext.toast(response.data && response.data.message || 'Please try again or report the issue to an administrator', 'Failed to save rating');
                 }

--- a/sencha-workspace/SlateTasksTeacher/app/controller/Dashboard.js
+++ b/sencha-workspace/SlateTasksTeacher/app/controller/Dashboard.js
@@ -384,14 +384,14 @@ Ext.define('SlateTasksTeacher.controller.Dashboard', {
             callback: function(opts, success, response) {
                 // var record = response.data.record;
 
-                if (success) {
+                if (success && response.data && response.data.success) {
                     me.getStudentTasksStore().load({
                         id: studentTask.getId(),
                         addRecords: true
                     });
                     // studentTask.set(record);
                 } else {
-                    Ext.toast('Error. Please try again.');
+                    Ext.toast(response.data && response.data.error || 'Please try again or report the issue to an administrator', 'Failed to save rating');
                 }
             }
         });

--- a/sencha-workspace/SlateTasksTeacher/app/controller/Dashboard.js
+++ b/sencha-workspace/SlateTasksTeacher/app/controller/Dashboard.js
@@ -369,7 +369,7 @@ Ext.define('SlateTasksTeacher.controller.Dashboard', {
         me.doEditStudentTask(studentTask);
     },
 
-    onRateSkillClick: function(ratingView, ratingObject) {
+    onRateSkillClick: function(ratingView, ratingData) {
         var me = this,
             taskRater = me.getTaskRater(),
             studentTask = taskRater.getStudentTask();
@@ -378,8 +378,8 @@ Ext.define('SlateTasksTeacher.controller.Dashboard', {
             url: studentTask.toUrl() + '/rate',
             method: 'POST',
             params: {
-                SkillID: ratingObject.SkillID,
-                Rating: ratingObject.rating,
+                SkillID: ratingData.SkillID,
+                Rating: ratingData.Rating,
             },
             callback: function(opts, success, response) {
                 // var record = response.data.record;

--- a/sencha-workspace/SlateTasksTeacher/app/controller/Dashboard.js
+++ b/sencha-workspace/SlateTasksTeacher/app/controller/Dashboard.js
@@ -379,7 +379,7 @@ Ext.define('SlateTasksTeacher.controller.Dashboard', {
             method: 'POST',
             params: {
                 SkillID: ratingObject.SkillID,
-                Score: ratingObject.rating
+                Rating: ratingObject.rating,
             },
             callback: function(opts, success, response) {
                 // var record = response.data.record;

--- a/sencha-workspace/SlateTasksTeacher/app/controller/Dashboard.js
+++ b/sencha-workspace/SlateTasksTeacher/app/controller/Dashboard.js
@@ -391,7 +391,7 @@ Ext.define('SlateTasksTeacher.controller.Dashboard', {
                     });
                     // studentTask.set(record);
                 } else {
-                    Ext.toast(response.data && response.data.error || 'Please try again or report the issue to an administrator', 'Failed to save rating');
+                    Ext.toast(response.data && response.data.message || 'Please try again or report the issue to an administrator', 'Failed to save rating');
                 }
             }
         });

--- a/sencha-workspace/SlateTasksTeacher/app/view/TaskRater.js
+++ b/sencha-workspace/SlateTasksTeacher/app/view/TaskRater.js
@@ -45,7 +45,7 @@ Ext.define('SlateTasksTeacher.view.TaskRater', {
         submissionsCmp.setData(studentTask.get('Submissions'));
         skillsField.setSkills(studentTask.get('Skills'), true, false); // appendSkills, editable
         ratingsView.setData({
-            ratings: [7, 8, 9, 10, 11, 12, 'M'],
+            ratings: [7, 8, 9, 10, 11, 12, 0],
             competencies: groupedSkills
         });
     },

--- a/sencha-workspace/SlateTasksTeacher/app/view/TaskRater.js
+++ b/sencha-workspace/SlateTasksTeacher/app/view/TaskRater.js
@@ -9,8 +9,7 @@ Ext.define('SlateTasksTeacher.view.TaskRater', {
     updateTask: function(task) {
         var me = this,
             form = me.down('slate-modalform'),
-            attachmentsField = me.down('slate-tasks-attachmentsfield'),
-            skillsField = me.down('slate-skillsfield');
+            attachmentsField = me.down('slate-tasks-attachmentsfield');
 
         form.down('[name=Title]').setValue(task.get('Title'));
         form.down('[name=ParentTaskTitle]').setValue(task.get('ParentTask') ? task.get('ParentTask').Title : '');
@@ -19,9 +18,6 @@ Ext.define('SlateTasksTeacher.view.TaskRater', {
 
         attachmentsField.setAttachments(task.get('Attachments'));
         attachmentsField.setReadOnly(true);
-
-        skillsField.setSkills(task.get('Skills'));
-        skillsField.setReadOnly(true);
     },
 
     updateStudentTask: function(studentTask) {
@@ -30,7 +26,6 @@ Ext.define('SlateTasksTeacher.view.TaskRater', {
             ratingsView = me.down('slate-ratingview'),
             commentsField = form.down('slate-commentsfield'),
             submissionsCmp = form.down('slate-tasks-submissions'),
-            skillsField = me.down('slate-skillsfield'),
             groupedSkills = studentTask.getTaskSkillsGroupedByCompetency();
 
         if (studentTask.get('DueDate')) {
@@ -43,7 +38,6 @@ Ext.define('SlateTasksTeacher.view.TaskRater', {
         form.down('#student-attachments').setAttachments(studentTask.get('Attachments'));
         commentsField.setRecord(studentTask);
         submissionsCmp.setData(studentTask.get('Submissions'));
-        skillsField.setSkills(studentTask.get('Skills'), true, false); // appendSkills, editable
         ratingsView.setData({
             ratings: [7, 8, 9, 10, 11, 12, 0],
             competencies: groupedSkills

--- a/sencha-workspace/packages/slate-cbl/sass/src/widget/RatingView.scss
+++ b/sencha-workspace/packages/slate-cbl/sass/src/widget/RatingView.scss
@@ -75,22 +75,6 @@
     margin: 1em 0;
 }
 
-.slate-ratingview-remove {
-    background: none;
-    border: none;
-    box-shadow: none;
-    color: #999;
-    line-height: 1;
-    margin: -1px .5em 0 0;
-    padding: 0;
-
-    &:hover,
-    &:focus {
-        background: none;
-        color: $color;
-    }
-}
-
 .slate-ratingview-skill-title {
     font-family: $body-font;
     font-weight: normal;
@@ -142,28 +126,15 @@
     background: none !important;
     position: relative;
 
-    &::before {
-        color: $danger-color;
-        content: '\f00d'; // fa-times
-        font-family: FontAwesome;
-        font-size: 14px;
-        left: 50%;
-        position: absolute;
-        transform: translate(-50%, -50%);
-        top: 50%;
-    }
-
     .slate-ratingview-rating-bubble {
         background-color: $neutral-color !important;
         border-color: $neutral-dark-color !important;
-        opacity: 0;
         position: relative;
         z-index: 1;
 
-        &:hover,
-        &:focus,
-        &:active {
-            opacity: 1;
+        &:hover {
+            border: 1px dashed #666;
+            cursor: context-menu;
         }
     }
 

--- a/sencha-workspace/packages/slate-cbl/sass/src/widget/RatingView.scss
+++ b/sencha-workspace/packages/slate-cbl/sass/src/widget/RatingView.scss
@@ -116,6 +116,19 @@
     justify-content: center;
     margin: auto;
     width: $slate-ratingview-bubble-size;
+
+    &:hover,
+    &:focus {
+        background-color: mix(white, #ccc, 75%);
+    }
+
+    &:active {
+        background-color: #ccc;
+    }
+}
+
+.is-selected .slate-ratingview-rating-bubble {
+    background-color: #ccc;
 }
 
 .slate-ratingview-rating-label {

--- a/sencha-workspace/packages/slate-cbl/sass/src/widget/RatingView.scss
+++ b/sencha-workspace/packages/slate-cbl/sass/src/widget/RatingView.scss
@@ -144,11 +144,6 @@
         border-color: $neutral-dark-color !important;
         position: relative;
         z-index: 1;
-
-        &:hover {
-            border: 1px dashed #666;
-            cursor: context-menu;
-        }
     }
 
     &.is-selected .slate-ratingview-rating-bubble {
@@ -160,4 +155,9 @@
         font-size: .6em;
         font-weight: bold;
     }
+}
+
+.slate-ratingview-rating-menu .slate-ratingview-rating-bubble:hover {
+    border: 1px dashed #666;
+    cursor: context-menu;
 }

--- a/sencha-workspace/packages/slate-cbl/src/view/modals/RateTask.js
+++ b/sencha-workspace/packages/slate-cbl/src/view/modals/RateTask.js
@@ -110,10 +110,6 @@ Ext.define('Slate.cbl.view.modals.RateTask', {
                     readOnly: true
                 },
                 {
-                    xtype: 'slate-skillsfield',
-                    fieldLabel: 'Skills'
-                },
-                {
                     xtype: 'slate-ratingview'
                 },
                 {

--- a/sencha-workspace/packages/slate-cbl/src/widget/RatingView.js
+++ b/sencha-workspace/packages/slate-cbl/src/widget/RatingView.js
@@ -76,7 +76,7 @@ Ext.define('Slate.cbl.widget.RatingView', {
                     return rating;
                 }
 
-                return 'N/A';
+                return null;
             },
 
             getMenuRatingElLabel: function(rating, menuRatings) {
@@ -139,7 +139,7 @@ Ext.define('Slate.cbl.widget.RatingView', {
         if (!me.getReadOnly()) {
             if (isRemoveEl) {
                 naRatingEl = target.parent('.slate-ratingview-skill').down('.slate-ratingview-rating-menu');
-                me.updateRatingEl(naRatingEl, 'N/A');
+                me.updateRatingEl(naRatingEl, null);
                 me.selectRating(naRatingEl, false);
             } else if (isRatingEl) {
                 me.selectRating(target);
@@ -151,7 +151,7 @@ Ext.define('Slate.cbl.widget.RatingView', {
         var me = this,
             skillEl = target.parent('.slate-ratingview-skill'),
 
-            rating = target.getAttribute('data-rating') || 'N/A',
+            rating = target.getAttribute('data-rating') || null,
             competency = skillEl.getAttribute('data-competency'),
             skill = skillEl.getAttribute('data-skill'),
 
@@ -166,11 +166,7 @@ Ext.define('Slate.cbl.widget.RatingView', {
         // deselect other ratings
         ratingEls.removeCls('is-selected');
 
-        if (rating == 'N/A') {
-            naRating.addCls('slate-ratingview-rating-null');
-        } else {
-            naRating.removeCls('slate-ratingview-rating-null');
-        }
+        naRating.toggleCls('slate-ratingview-rating-null', !rating);
 
         target.addCls('is-selected');
 

--- a/sencha-workspace/packages/slate-cbl/src/widget/RatingView.js
+++ b/sencha-workspace/packages/slate-cbl/src/widget/RatingView.js
@@ -171,9 +171,9 @@ Ext.define('Slate.cbl.widget.RatingView', {
         target.addCls('is-selected');
 
         return me.fireEvent('rateskill', me, {
-            rating: rating,
+            CompetencyID: competency,
             SkillID: skill,
-            CompetencyID: competency
+            Rating: rating
         });
     },
 

--- a/sencha-workspace/packages/slate-cbl/src/widget/RatingView.js
+++ b/sencha-workspace/packages/slate-cbl/src/widget/RatingView.js
@@ -132,34 +132,38 @@ Ext.define('Slate.cbl.widget.RatingView', {
     onScaleClick: function(ev, t) {
         var me = this,
             target = Ext.get(t),
-            isRatingEl = target.is('.slate-ratingview-rating'),
-            isRemoveEl = target.is('.slate-ratingview-remove'),
-            naRatingEl;
+            menuThumbEl;
 
+        if (me.getReadOnly()) {
+            return;
+        }
 
-        if (!me.getReadOnly()) {
-            if (isRemoveEl) {
-                naRatingEl = target.parent('.slate-ratingview-skill').down('.slate-ratingview-rating-menu');
-                me.updateRatingEl(naRatingEl, null);
-                me.selectRating(naRatingEl, false);
-            } else if (isRatingEl) {
-                me.selectRating(target);
-            }
+        if (target.is('.slate-ratingview-rating-menu')) {
+            me.showMenu(target, target.getXY());
+            return;
+        }
+
+        if (target.hasCls('is-selected')) {
+            return;
+        }
+
+        if (target.is('.slate-ratingview-remove')) {
+            menuThumbEl = target.parent('.slate-ratingview-skill').down('.slate-ratingview-rating-menu');
+            me.updateRatingEl(menuThumbEl, null);
+            me.selectRating(menuThumbEl, false);
+        } else {
+            me.selectRating(target);
         }
     },
 
-    selectRating: function(target, showMenu) {
+    selectRating: function(target) {
         var me = this,
             skillEl = target.parent('.slate-ratingview-skill'),
             menuThumbEl = skillEl.down('.slate-ratingview-rating-menu'),
             rating = target.getAttribute('data-rating') || null;
 
-        if (target === menuThumbEl && showMenu !== false) {
-            return me.showMenu(target, target.getXY());
-        }
-
         target.radioCls('is-selected');
-        menuThumbEl.toggleCls('slate-ratingview-rating-null', rating === null);
+        menuThumbEl.toggleCls('slate-ratingview-rating-null', rating !== null);
 
         // if rating is being removed, revert level styling to current competency level that future ratings would get logged against
         if (rating === null) {

--- a/sencha-workspace/packages/slate-cbl/src/widget/RatingView.js
+++ b/sencha-workspace/packages/slate-cbl/src/widget/RatingView.js
@@ -27,9 +27,6 @@ Ext.define('Slate.cbl.widget.RatingView', {
                         '<tpl for="skills">',
                             '<li class="slate-ratingview-skill slate-ratingview-skill-level-{[values.Level || values.CompetencyLevel]}" data-competency="{[parent.Code]}" data-skill="{Code}" data-competency-level="{CompetencyLevel}" data-level="{Level}">',
                                 '<header class="slate-ratingview-skill-header">',
-                                    '<tpl if="!this.readOnly">', // hide when in readOnly mode
-                                        '<button class="slate-ratingview-remove"><i class="fa fa-times-circle"></i></button>',
-                                    '</tpl>',
                                     '<h5 class="slate-ratingview-skill-title">{Code}<tpl if="Code &amp;&amp; Descriptor"> – </tpl>{Descriptor}</h5>',
                                 '</header>',
                                 '<ol class="slate-ratingview-ratings">',
@@ -95,7 +92,7 @@ Ext.define('Slate.cbl.widget.RatingView', {
         click: {
             fn: 'onScaleClick',
             element: 'el',
-            delegate: ['.slate-ratingview-rating', '.slate-ratingview-remove']
+            delegate: '.slate-ratingview-rating'
         }
     },
 
@@ -131,8 +128,7 @@ Ext.define('Slate.cbl.widget.RatingView', {
 
     onScaleClick: function(ev, t) {
         var me = this,
-            target = Ext.get(t),
-            menuThumbEl;
+            target = Ext.get(t);
 
         if (me.getReadOnly()) {
             return;
@@ -147,13 +143,7 @@ Ext.define('Slate.cbl.widget.RatingView', {
             return;
         }
 
-        if (target.is('.slate-ratingview-remove')) {
-            menuThumbEl = target.parent('.slate-ratingview-skill').down('.slate-ratingview-rating-menu');
-            me.updateRatingEl(menuThumbEl, null);
-            me.selectRating(menuThumbEl, false);
-        } else {
             me.selectRating(target);
-        }
     },
 
     selectRating: function(target) {
@@ -221,7 +211,7 @@ Ext.define('Slate.cbl.widget.RatingView', {
         var me = this;
 
         me.updateRatingEl(menu.ratingEl, menuRating.getValue());
-        me.selectRating(menu.ratingEl, false);
+        me.selectRating(menu.ratingEl);
         menu.hide();
     }
 });

--- a/sencha-workspace/packages/slate-cbl/src/widget/RatingView.js
+++ b/sencha-workspace/packages/slate-cbl/src/widget/RatingView.js
@@ -32,9 +32,9 @@ Ext.define('Slate.cbl.widget.RatingView', {
                                     '<h5 class="slate-ratingview-skill-title">{Code}<tpl if="Code &amp;&amp; Descriptor"> – </tpl>{Descriptor}</h5>',
                                 '</header>',
                                 '<ol class="slate-ratingview-ratings">',
-                                    '<li class="slate-ratingview-rating slate-ratingview-rating-menu slate-ratingview-rating-null{[this.getMenuRatingElCls(values.Rating, this)]}" data-rating="{[this.getMenuElRatingValue(values.Rating, this)]}">',
+                                    '<li class="slate-ratingview-rating slate-ratingview-rating-menu slate-ratingview-rating-null{[this.getMenuRatingElCls(values.Rating, this.menuRatings)]}" data-rating="{[this.getMenuElRatingValue(values.Rating, this.menuRatings)]}">',
                                         '<div class="slate-ratingview-rating-bubble" tabindex="0">',
-                                            '<span class="slate-ratingview-rating-label">{[this.getMenuRatingElLabel(values.Rating, this)]}</span>',
+                                            '<span class="slate-ratingview-rating-label">{[this.getMenuRatingElLabel(values.Rating, this.menuRatings)]}</span>',
                                         '</div>',
                                     '</li>',
                                     '<tpl for="this.ratings">', // access template-scoped variable declared at top
@@ -61,26 +61,26 @@ Ext.define('Slate.cbl.widget.RatingView', {
                 return rating;
             },
 
-            getMenuRatingElCls: function(rating, scope) {
+            getMenuRatingElCls: function(rating, menuRatings) {
                 var cls = '';
 
-                if (rating === null || scope.menuRatings.indexOf(rating) > -1) {
+                if (rating === null || menuRatings.indexOf(rating) > -1) {
                     cls += ' is-selected';
                 }
 
                 return cls;
             },
 
-            getMenuElRatingValue: function(rating, scope) {
-                if (rating && scope.menuRatings.indexOf(rating) > -1) {
+            getMenuElRatingValue: function(rating, menuRatings) {
+                if (rating && menuRatings.indexOf(rating) > -1) {
                     return rating;
                 }
 
                 return 'N/A';
             },
 
-            getMenuRatingElLabel: function(rating, scope) {
-                if (scope.menuRatings.indexOf(rating) > -1) {
+            getMenuRatingElLabel: function(rating, menuRatings) {
+                if (menuRatings.indexOf(rating) > -1) {
                     return rating;
                 }
 
@@ -182,10 +182,11 @@ Ext.define('Slate.cbl.widget.RatingView', {
     },
 
     updateRatingEl: function(el, rating) {
-        var text = rating || 'N/A';
+        var tpl = this.lookupTpl('tpl'),
+            menuRatings = this.getMenuRatings();
 
-        el.dom.setAttribute('data-rating', text);
-        el.down('.slate-ratingview-rating-label').setHtml(text);
+        el.dom.setAttribute('data-rating', tpl.getMenuElRatingValue(rating, menuRatings) || '');
+        el.down('.slate-ratingview-rating-label').setHtml(tpl.getMenuRatingElLabel(rating, menuRatings));
     },
 
     showMenu: function(ratingEl, xy) {

--- a/sencha-workspace/packages/slate-cbl/src/widget/RatingView.js
+++ b/sencha-workspace/packages/slate-cbl/src/widget/RatingView.js
@@ -24,7 +24,7 @@ Ext.define('Slate.cbl.widget.RatingView', {
                     '<h4 class="slate-ratingview-competency-title">{Code}<tpl if="Code &amp;&amp; Descriptor"> – </tpl>{Descriptor}</h4>',
                     '<ul class="slate-ratingview-skills">',
                         '<tpl for="skills">',
-                            '<li class="slate-ratingview-skill slate-ratingview-skill-level-{CompetencyLevel}" data-competency="{[parent.Code]}" data-skill="{Code}">',
+                            '<li class="slate-ratingview-skill slate-ratingview-skill-level-{[values.Level || values.CompetencyLevel]}" data-competency="{[parent.Code]}" data-skill="{Code}">',
                                 '<header class="slate-ratingview-skill-header">',
                                     '<tpl if="!this.readOnly">', // hide when in readOnly mode
                                         '<button class="slate-ratingview-remove"><i class="fa fa-times-circle"></i></button>',

--- a/sencha-workspace/packages/slate-cbl/src/widget/RatingView.js
+++ b/sencha-workspace/packages/slate-cbl/src/widget/RatingView.js
@@ -32,7 +32,7 @@ Ext.define('Slate.cbl.widget.RatingView', {
                                     '<h5 class="slate-ratingview-skill-title">{Code}<tpl if="Code &amp;&amp; Descriptor"> – </tpl>{Descriptor}</h5>',
                                 '</header>',
                                 '<ol class="slate-ratingview-ratings">',
-                                    '<li class="slate-ratingview-rating slate-ratingview-rating-menu slate-ratingview-rating-null{[this.getMenuRatingElCls(values.Rating, this.menuRatings)]}" data-rating="{[this.getMenuElRatingValue(values.Rating, this.menuRatings)]}">',
+                                    '<li class="slate-ratingview-rating slate-ratingview-rating-menu slate-ratingview-rating-null {[this.getMenuRatingElCls(values.Rating, this.menuRatings)]}" data-rating="{[this.getMenuElRatingValue(values.Rating, this.menuRatings)]}">',
                                         '<div class="slate-ratingview-rating-bubble" tabindex="0">',
                                             '<span class="slate-ratingview-rating-label">{[this.getMenuRatingElLabel(values.Rating, this.menuRatings)]}</span>',
                                         '</div>',
@@ -65,7 +65,7 @@ Ext.define('Slate.cbl.widget.RatingView', {
                 var cls = '';
 
                 if (rating === null || menuRatings.indexOf(rating) > -1) {
-                    cls += ' is-selected';
+                    cls += 'is-selected';
                 }
 
                 return cls;
@@ -218,7 +218,7 @@ Ext.define('Slate.cbl.widget.RatingView', {
 
     onMenuRatingClick: function(menu, menuRating) {
         var me = this;
-        console.log('onMenuRatingClick');
+
         me.updateRatingEl(menu.ratingEl, menuRating.getValue());
         me.selectRating(menu.ratingEl, false);
         menu.hide();

--- a/site-root/cbl/student-competencies.php
+++ b/site-root/cbl/student-competencies.php
@@ -1,0 +1,3 @@
+<?php
+
+Slate\CBL\StudentCompetenciesRequestHandler::handleRequest();


### PR DESCRIPTION
- Update/skip deprecated migrations
- Fix skip condition for DemonstrationsRequired int->json migration
- Flip sign for `$minimumRatingOffset` configuration
- Fix two bugs that could duplicated DemonstrationSkill records when interacted with from the tasks UI; add migration to clean data
- Prevent errors when data browsed without Drive API configured
- Improved teacher task rating UI behavior and defaulted sliders to gray
- Fix division by zero error when competencies have no skills
- Add /cbl/student-competencies API and basic browse+details UIs