### PR TITLE
Improve styling for rating and level sliders

### DIFF
--- a/sencha-workspace/packages/slate-cbl/sass/src/field/LevelSlider.scss
+++ b/sencha-workspace/packages/slate-cbl/sass/src/field/LevelSlider.scss
@@ -14,9 +14,9 @@
             content: '\00d7'; // times
             font-size: large;
             font-weight: bold;
-            left: 26px;
+            left: 24px;
             position: absolute;
-            top: 6px;
+            top: 1px;
         }
     }
 

--- a/sencha-workspace/packages/slate-cbl/sass/src/widget/RatingView.scss
+++ b/sencha-workspace/packages/slate-cbl/sass/src/widget/RatingView.scss
@@ -132,6 +132,19 @@
     justify-content: center;
     margin: auto;
     width: $slate-ratingview-bubble-size;
+
+    &:hover,
+    &:focus {
+        background-color: mix(white, #ccc, 75%);
+    }
+
+    &:active {
+        background-color: #ccc;
+    }
+}
+
+.is-selected .slate-ratingview-rating-bubble {
+    background-color: #ccc;
 }
 
 .slate-ratingview-rating-label {

--- a/sencha-workspace/packages/slate-cbl/src/widget/RatingView.js
+++ b/sencha-workspace/packages/slate-cbl/src/widget/RatingView.js
@@ -166,7 +166,7 @@ Ext.define('Slate.cbl.widget.RatingView', {
         // deselect other ratings
         ratingEls.removeCls('is-selected');
 
-        if (rating == 'N/A') {
+        if (me.getMenuRatings().includes(parseInt(rating)) == false) {
             naRating.addCls('slate-ratingview-rating-null');
         } else {
             naRating.removeCls('slate-ratingview-rating-null');


### PR DESCRIPTION
The one line I'm not sure about is https://github.com/SlateFoundation/slate-cbl/compare/styling?expand=1#diff-2eb74777bbceddc93e313dfa920a135cR169 — the `parseInt()` seems a little fragile, but I'm not sure what a better way might be to check for the rating in the array.

**Gray selected colors and more appropriate font sizes:**
![screenshot 2017-10-18 20 40 22](https://user-images.githubusercontent.com/1154929/31749143-16698094-b446-11e7-8234-38e6903a5b05.png)
![screenshot 2017-10-18 20 40 34](https://user-images.githubusercontent.com/1154929/31749144-1677825c-b446-11e7-82d8-736febf5ed61.png)

**&times; alignment:**
![screenshot 2017-10-18 20 49 42](https://user-images.githubusercontent.com/1154929/31749145-168d096a-b446-11e7-961e-309f34040f55.png)
