### PR TITLE
Release: slate-cbl v3.0.0-beta.5

### DIFF
--- a/php-migrations/Slate/CBL/Tasks/20181111_todo-indexes.php
+++ b/php-migrations/Slate/CBL/Tasks/20181111_todo-indexes.php
@@ -4,6 +4,11 @@ namespace Slate\CBL\Tasks;
 
 $status = static::STATUS_SKIPPED;
 
+// skip if table does not exist yet
+if (!static::tableExists(Todo::$tableName)) {
+    printf("Skipping migration because table `%s` does not yet exist\n", Todo::$tableName);
+    return $status;
+}
 
 // ensure StudentID column has index
 if (!static::getColumn(Todo::$tableName, 'StudentID')['COLUMN_KEY']) {

--- a/sencha-workspace/SlateDemonstrationsStudent/app/view/CompetencyCard.js
+++ b/sencha-workspace/SlateDemonstrationsStudent/app/view/CompetencyCard.js
@@ -128,9 +128,16 @@ Ext.define('SlateDemonstrationsStudent.view.CompetencyCard', {
                 '<ul class="cbl-skill-demos">',
                     '<tpl for="demonstrations">',
                         '<tpl if=".">',
-                            '<li ',
-                                'data-demonstration="{DemonstrationID}"',
-                                'class="',
+                            '<li',
+                                ' data-demonstration="{DemonstrationID}"',
+                                ' title="',
+                                    '<tpl if="Override">',
+                                        'Overriden',
+                                    '<tpl else>',
+                                        '{[fm.htmlEncode(Slate.cbl.util.Config.getTitleForRating(values.DemonstratedLevel))]}',
+                                    '</tpl>',
+                                '"',
+                                ' class="',
                                     ' cbl-skill-demo',
                                     '<tpl if="Override">',
                                         ' cbl-skill-override',
@@ -145,10 +152,8 @@ Ext.define('SlateDemonstrationsStudent.view.CompetencyCard', {
                             '>',
                                 '<tpl if="Override">',
                                     '<i class="fa fa-check"></i>',
-                                '<tpl elseif="DemonstratedLevel == 0">',
-                                    'M',
                                 '<tpl else>',
-                                    '{DemonstratedLevel}',
+                                    '{[fm.htmlEncode(Slate.cbl.util.Config.getAbbreviationForRating(values.DemonstratedLevel))]}',
                                 '</tpl>',
                             '</li>',
                             '{% if (values.Override) break; %}', // don't print any more blocks after override
@@ -250,7 +255,13 @@ Ext.define('SlateDemonstrationsStudent.view.CompetencyCard', {
         }
 
         if (me.rendered) {
-            me.meterLevelEl.update(newLevel ? Slate.cbl.util.Config.getTitleForLevel(newLevel) : '');
+            me.meterLevelEl.update(
+                newLevel
+                    ? Ext.util.Format.htmlEncode(
+                        Slate.cbl.util.Config.getTitleForLevel(newLevel)
+                    )
+                    : ''
+            );
         }
     },
 

--- a/sencha-workspace/SlateDemonstrationsStudent/app/view/Dashboard.js
+++ b/sencha-workspace/SlateDemonstrationsStudent/app/view/Dashboard.js
@@ -117,7 +117,7 @@ Ext.define('SlateDemonstrationsStudent.view.Dashboard', {
                 }
             ]
         },
-        placeholderItem: 'Select a content area to load demonstrations dashboard',
+        placeholderItem: 'Select a content area to load demonstrations dashboard'
     },
 
 

--- a/sencha-workspace/SlateDemonstrationsTeacher/app/view/ProgressGrid.js
+++ b/sencha-workspace/SlateDemonstrationsTeacher/app/view/ProgressGrid.js
@@ -11,6 +11,8 @@ Ext.define('SlateDemonstrationsTeacher.view.ProgressGrid', {
     extend: 'Ext.Component',
     xtype: 'slate-demonstrations-teacher-progressgrid',
     requires: [
+        'Ext.util.Format',
+
         /* global Slate */
         'Slate.cbl.widget.Popover',
         'Slate.cbl.util.Config'
@@ -116,10 +118,13 @@ Ext.define('SlateDemonstrationsTeacher.view.ProgressGrid', {
                     '</table>',
                 '</div>',
             '</div>',
+
             '<div class="cbl-grid-legend">',
                 '<span class="cbl-grid-legend-label">Portfolios:&ensp;</span>',
                 '<tpl foreach="Slate.cbl.util.Config.getLevels()">',
-                    '<span class="cbl-grid-legend-item level-color cbl-level-{$}">{title}</span>',
+                    '<tpl if="xkey != 0">',
+                        '<span class="cbl-grid-legend-item level-color cbl-level-{$}" title="{title:htmlEncode}">{abbreviation:htmlEncode}</span>',
+                    '</tpl>',
                 '</tpl>',
             '</div>',
 
@@ -163,6 +168,13 @@ Ext.define('SlateDemonstrationsTeacher.view.ProgressGrid', {
                                     '<li',
                                         ' data-demonstration="{DemonstrationID}"',
                                         '<tpl if="Override"> data-span="{[xcount - xindex + 1]}"</tpl>',
+                                        ' title="',
+                                            '<tpl if="Override">',
+                                                'Overriden',
+                                            '<tpl else>',
+                                                '{[fm.htmlEncode(Slate.cbl.util.Config.getTitleForRating(values.DemonstratedLevel))]}',
+                                            '</tpl>',
+                                        '"',
                                         ' class="',
                                             ' cbl-grid-demo',
                                             '<tpl if="Override">',
@@ -179,10 +191,8 @@ Ext.define('SlateDemonstrationsTeacher.view.ProgressGrid', {
                                     '>',
                                         '<tpl if="Override">',
                                             '<i class="fa fa-check"></i>',
-                                        '<tpl elseif="DemonstratedLevel == 0">',
-                                            'M',
                                         '<tpl else>',
-                                            '{DemonstratedLevel}',
+                                            '{[fm.htmlEncode(Slate.cbl.util.Config.getAbbreviationForRating(values.DemonstratedLevel))]}',
                                         '</tpl>',
                                     '</li>',
                                     '{% if (values.Override) break; %}', // don't print any more blocks after override
@@ -680,6 +690,7 @@ Ext.define('SlateDemonstrationsTeacher.view.ProgressGrid', {
 
         // eslint-disable-next-line vars-on-top
         var me = this,
+            htmlEncode = Ext.util.Format.htmlEncode,
             competenciesById,
 
             studentCompetenciesLength = studentCompetencies.length,
@@ -794,7 +805,10 @@ Ext.define('SlateDemonstrationsTeacher.view.ProgressGrid', {
 
                 progressCellEl.addCls('cbl-level-'+level);
 
-                node.progressLevelEl.update(Slate.cbl.util.Config.getTitleForLevel(level));
+                node.progressLevelEl
+                    .set({ title: Slate.cbl.util.Config.getTitleForLevel(level) })
+                    .update(htmlEncode(Slate.cbl.util.Config.getAbbreviationForLevel(level)));
+
                 node.renderedLevel = level;
             }
 
@@ -869,10 +883,8 @@ Ext.define('SlateDemonstrationsTeacher.view.ProgressGrid', {
                         // TODO: use a global template
                         if (demonstrationOverride) {
                             demonstrationHtml = '<i class="fa fa-check"></i>';
-                        } else if (demonstrationRating == 0) {
-                            demonstrationHtml = 'M';
                         } else {
-                            demonstrationHtml = demonstrationRating;
+                            demonstrationHtml = htmlEncode(Slate.cbl.util.Config.getTitleForRating(demonstrationRating));
                         }
 
                         demonstrationBlockEl.update(demonstrationHtml);

--- a/sencha-workspace/packages/slate-cbl/src/field/ratings/Thumb.js
+++ b/sencha-workspace/packages/slate-cbl/src/field/ratings/Thumb.js
@@ -3,15 +3,19 @@
  */
 Ext.define('Slate.cbl.field.ratings.Thumb', {
     extend: 'Ext.slider.Thumb',
+    requires: [
+        'Ext.util.Format',
+
+        /* global Slate */
+        'Slate.cbl.util.Config'
+    ],
 
 
     contentTpl: [
         '<tpl if="value === null">',
             '<small class="muted">N/A</small>',
-        '<tpl elseif="value === 0">',
-            'M',
         '<tpl else>',
-            '{value}',
+            '{[fm.htmlEncode(Slate.cbl.util.Config.getAbbreviationForRating(values.value))]}',
         '</tpl>'
     ],
 
@@ -21,6 +25,7 @@ Ext.define('Slate.cbl.field.ratings.Thumb', {
             config = me.callParent();
 
         config.html = me.buildValueHtml(me.value);
+        config.title = Slate.cbl.util.Config.getTitleForRating(me.value);
 
         if (thumbCls) {
             config.cls += ' ' + thumbCls;
@@ -40,7 +45,8 @@ Ext.define('Slate.cbl.field.ratings.Thumb', {
         me.value = value;
 
         if (el) {
-            el.setHtml(me.buildValueHtml(value));
+            el.set({ title: Slate.cbl.util.Config.getTitleForRating(value) })
+                .setHtml(me.buildValueHtml(value));
         }
     },
 

--- a/sencha-workspace/packages/slate-cbl/src/util/Config.js
+++ b/sencha-workspace/packages/slate-cbl/src/util/Config.js
@@ -5,18 +5,23 @@ Ext.define('Slate.cbl.util.Config', {
     config: {
         levels: {
             9: {
-                title: 'Y1'
+                title: 'Year 1',
+                abbreviation: 'Y1'
             },
             10: {
-                title: 'Y2'
+                title: 'Year 2',
+                abbreviation: 'Y1'
             },
             11: {
-                title: 'Y3'
+                title: 'Year 3',
+                abbreviation: 'Y1'
             },
             12: {
-                title: 'Y4'
+                title: 'Year 4',
+                abbreviation: 'Y1'
             }
-        }
+        },
+        ratings: {}
     },
 
 
@@ -29,6 +34,39 @@ Ext.define('Slate.cbl.util.Config', {
     getTitleForLevel: function(level) {
         var levelConfig = this.getLevels()[level];
 
-        return levelConfig ? levelConfig.title : level;
+        if (levelConfig) {
+            return levelConfig.title || levelConfig.abbreviation;
+        }
+
+        return level;
+    },
+
+    getAbbreviationForLevel: function(level) {
+        var levelConfig = this.getLevels()[level];
+
+        if (levelConfig) {
+            return levelConfig.abbreviation || levelConfig.title;
+        }
+
+        return level;
+    },
+
+    getTitleForRating: function(rating) {
+        var ratingConfig = this.getRatings()[rating];
+
+        if (ratingConfig) {
+            return ratingConfig.title || ratingConfig.abbreviation;
+        }
+
+        return rating == '0' ? 'M' : rating;
+    },
+
+    getAbbreviationForRating: function(rating) {
+        var ratingConfig = this.getRatings()[rating];
+
+        if (ratingConfig) {
+            return ratingConfig.abbreviation || ratingConfig.title;
+        }
+        return rating == '0' ? 'M' : rating;
     }
 });

--- a/sencha-workspace/packages/slate-cbl/src/view/demonstrations/SkillList.js
+++ b/sencha-workspace/packages/slate-cbl/src/view/demonstrations/SkillList.js
@@ -5,8 +5,10 @@ Ext.define('Slate.cbl.view.demonstrations.SkillList', {
     extend: 'Ext.view.View',
     xtype: 'slate-cbl-demonstrations-skilllist',
     requires: [
-        'Slate.cbl.store.demonstrations.DemonstrationSkills',
-        'Slate.API'
+        'Slate.API',
+
+        'Slate.cbl.util.Config',
+        'Slate.cbl.store.demonstrations.DemonstrationSkills'
     ],
 
 
@@ -59,13 +61,20 @@ Ext.define('Slate.cbl.view.demonstrations.SkillList', {
                     '<td class="skill-list-demo-data skill-list-demo-index">{[xindex]}</td>',
                     '<td class="skill-list-demo-data skill-list-demo-date">{Demonstrated:date}</td>',
                     '<td class="skill-list-demo-data skill-list-demo-level">',
-                        '<div class="level-color cbl-level-{TargetLevel}">',
+                        '<div',
+                            ' class="level-color cbl-level-{TargetLevel}"',
+                            ' title="',
+                                '<tpl if="Override">',
+                                    'Overriden',
+                                '<tpl else>',
+                                    '{[fm.htmlEncode(Slate.cbl.util.Config.getTitleForRating(values.DemonstratedLevel))]}',
+                                '</tpl>',
+                            '"',
+                        '>',
                             '<tpl if="Override">',
                                 '<i class="fa fa-check"></i>',
-                            '<tpl elseif="DemonstratedLevel==0">',
-                                'M',
                             '<tpl else>',
-                                '{DemonstratedLevel}',
+                                '{[fm.htmlEncode(Slate.cbl.util.Config.getAbbreviationForRating(values.DemonstratedLevel))]}',
                             '</tpl>',
                         '</div>',
                     '</td>',


### PR DESCRIPTION
- fix: skip todo indexes migration when table does not exist yet
- feat: support custom rating/level titles and abbreviations throughout