### PR TITLE
Release: slate-cbl v3.0.0-beta.6

### DIFF
--- a/sencha-workspace/SlateDemonstrationsStudent/app/view/CompetencyCard.js
+++ b/sencha-workspace/SlateDemonstrationsStudent/app/view/CompetencyCard.js
@@ -83,7 +83,7 @@ Ext.define('SlateDemonstrationsStudent.view.CompetencyCard', {
             '</table>',
         '</div>',
 
-        '<div class="slate-simplepanel-body explainer">',
+        '<div id="{id}-explainerEl" data-ref="explainerEl" class="slate-simplepanel-body explainer" <tpl if="!competency.Statement">style="display:none"</tpl>>',
             '<p id="{id}-statementEl" data-ref="statementEl">{[fm.preventOrphans(fm.htmlEncode(values.competency.Statement))]}</p>',
         '</div>',
 
@@ -105,6 +105,7 @@ Ext.define('SlateDemonstrationsStudent.view.CompetencyCard', {
         'averageEl',
         'baselineRatingEl',
         'growthEl',
+        'explainerEl',
         'statementEl',
         'skillsCt'
     ],
@@ -212,6 +213,7 @@ Ext.define('SlateDemonstrationsStudent.view.CompetencyCard', {
         var me = this,
             htmlEncode = Ext.util.Format.htmlEncode,
             studentCompetency = competency.get('currentStudentCompetency'),
+            statement = competency.get('Statement'),
             demonstrationsAverage, level, demonstrationsRequired, percentComplete;
 
         if (studentCompetency) {
@@ -236,7 +238,8 @@ Ext.define('SlateDemonstrationsStudent.view.CompetencyCard', {
         if (me.rendered) {
             me.codeEl.update(htmlEncode(competency.get('Code')));
             me.descriptorEl.update(htmlEncode(competency.get('Descriptor')));
-            me.statementEl.update(htmlEncode(competency.get('Statement')));
+            me.explainerEl.setDisplayed(Boolean(statement));
+            me.statementEl.update(htmlEncode(statement));
             me.lookupTpl('skillsTpl').overwrite(me.skillsCt, me.buildSkillsTplData(competency));
         }
 

--- a/sencha-workspace/SlateDemonstrationsStudent/app/view/CompetencyCard.js
+++ b/sencha-workspace/SlateDemonstrationsStudent/app/view/CompetencyCard.js
@@ -143,6 +143,8 @@ Ext.define('SlateDemonstrationsStudent.view.CompetencyCard', {
                                     '<tpl if="Override">',
                                         ' cbl-skill-override',
                                         ' cbl-skill-span-{[xcount - xindex + 1]}',
+                                    '<tpl else>',
+                                        ' cbl-rating-{DemonstratedLevel}',
                                     '</tpl>',
                                     '<tpl if="DemonstratedLevel || Override">',
                                         ' cbl-skill-demo-counted',

--- a/sencha-workspace/SlateDemonstrationsTeacher/app/view/ProgressGrid.js
+++ b/sencha-workspace/SlateDemonstrationsTeacher/app/view/ProgressGrid.js
@@ -179,6 +179,8 @@ Ext.define('SlateDemonstrationsTeacher.view.ProgressGrid', {
                                             ' cbl-grid-demo',
                                             '<tpl if="Override">',
                                                 ' cbl-grid-demo-override',
+                                            '<tpl else>',
+                                                ' cbl-rating-{DemonstratedLevel}',
                                             '</tpl>',
                                             '<tpl if="DemonstratedLevel || Override">',
                                                 ' cbl-grid-demo-counted',


### PR DESCRIPTION
- feat: hide container for competency statement when empty
- feat: add rating-based CSS classes for demonstration cells