### PR TITLE
Release: slate-cbl v3.0.0-beta.10

### DIFF
--- a/data-exporters/slate-cbl/student-tasks.php
+++ b/data-exporters/slate-cbl/student-tasks.php
@@ -3,7 +3,7 @@
 return [
     'title' => 'Student Tasks',
     'description' => 'Each row represents an assignment of a task to a student',
-    'filename' => 'student-competencies',
+    'filename' => 'student-tasks',
     'headers' => [
         'StudentFullName' => 'Student',
         'StudentNumber' => 'Student Number',

--- a/php-classes/Slate/CBL/StudentCompetency.php
+++ b/php-classes/Slate/CBL/StudentCompetency.php
@@ -278,10 +278,15 @@ class StudentCompetency extends \ActiveRecord
         return $this->demonstrationOpportunities;
     }
 
+    protected static function sortDemonstrations($a, $b)
+    {
+        return $a['ID'] < $b['ID'] ? -1 : 1;
+    }
+
     protected static function sortEffectiveDemonstrations($a, $b)
     {
         if ($a['DemonstratedLevel'] == $b['DemonstratedLevel']) {
-            return 0;
+            return static::sortDemonstrations($a, $b);
         }
 
         return $a['DemonstratedLevel'] < $b['DemonstratedLevel'] ? 1 : -1;
@@ -294,12 +299,14 @@ class StudentCompetency extends \ActiveRecord
             $demonstrationsData = $this->getDemonstrationData();
 
             foreach ($demonstrationsData as $skillId => &$demonstrationData) {
-                uasort($demonstrationData, [__CLASS__,  'sortEffectiveDemonstrations']);
+                usort($demonstrationData, [__CLASS__,  'sortEffectiveDemonstrations']);
 
                 $Skill = Skill::getByID($skillId);
                 $demonstrationsRequired = $Skill->getDemonstrationsRequiredByLevel($this->Level);
 
                 array_splice($demonstrationData, $demonstrationsRequired);
+
+                usort($demonstrationData, [__CLASS__,  'sortDemonstrations']);
             }
 
             $this->effectiveDemonstrationsData = $demonstrationsData;

--- a/sencha-workspace/SlateDemonstrationsStudent/app/view/CompetenciesSummary.js
+++ b/sencha-workspace/SlateDemonstrationsStudent/app/view/CompetenciesSummary.js
@@ -22,7 +22,7 @@ Ext.define('SlateDemonstrationsStudent.view.CompetenciesSummary', {
 
         // optional config
         percentFormat: '0%',
-        averageFormat: '0.##',
+        averageFormat: '0.#',
         growthFormat: '0.# yr',
     },
 

--- a/sencha-workspace/SlateDemonstrationsStudent/app/view/CompetencyCard.js
+++ b/sencha-workspace/SlateDemonstrationsStudent/app/view/CompetencyCard.js
@@ -17,7 +17,7 @@ Ext.define('SlateDemonstrationsStudent.view.CompetencyCard', {
 
         // optional config
         percentFormat: '0%',
-        averageFormat: '0.##',
+        averageFormat: '0.#',
         growthFormat: '0.# yr',
 
         // input-dependent state

--- a/sencha-workspace/SlateDemonstrationsTeacher/app/view/ProgressGrid.js
+++ b/sencha-workspace/SlateDemonstrationsTeacher/app/view/ProgressGrid.js
@@ -19,7 +19,7 @@ Ext.define('SlateDemonstrationsTeacher.view.ProgressGrid', {
     ],
 
     config: {
-        averageFormat: '0.##',
+        averageFormat: '0.#',
         progressFormat: '0%',
         contentArea: null,
 


### PR DESCRIPTION
- fix: show summary for lowest currently enrolled level instead of lowest incomplete level
- fix: correct filename for student-tasks.csv export
- fix: order demonstrations by ID after truncating non-effective
- style: round averages to nearest tenth