### PR TITLE
Release: slate-cbl v3.0.0-beta.11

### DIFF
--- a/sencha-workspace/SlateStudentCompetenciesAdmin/app/view/Grid.js
+++ b/sencha-workspace/SlateStudentCompetenciesAdmin/app/view/Grid.js
@@ -64,6 +64,10 @@ Ext.define('SlateStudentCompetenciesAdmin.view.Grid', {
                 }
             }
 
+            if (!rendered) {
+                cellEl.addCls('cbl-level-colored');
+            }
+
             if (rendered.level != highestLevel) {
                 if (rendered && rendered.level) {
                     cellEl.removeCls('cbl-level-'+rendered.level);
@@ -82,10 +86,7 @@ Ext.define('SlateStudentCompetenciesAdmin.view.Grid', {
             }
 
             if (rendered.phantom != highestIsPhantom) {
-                cellEl
-                    .toggleCls('cbl-level-phantom', highestIsPhantom)
-                    .toggleCls('cbl-level-colored-light', !highestIsPhantom)
-                    .toggleCls('cbl-level-colored', highestIsPhantom);
+                cellEl.toggleCls('cbl-level-phantom', highestIsPhantom);
             }
 
             if (rendered.id != highestId) {

--- a/sencha-workspace/SlateStudentCompetenciesAdmin/app/view/Grid.scss
+++ b/sencha-workspace/SlateStudentCompetenciesAdmin/app/view/Grid.scss
@@ -16,6 +16,10 @@
             }
         }
 
+        &:not(.cbl-level-phantom) {
+            opacity: 0.4;
+        }
+
         &.cbl-level-phantom {
             color: white;
             text-shadow: 0 1px 1px black;


### PR DESCRIPTION
- feat: use opacity instead of -light variant to mute existing enrollments