### PR TITLE
Release: slate-cbl v3.0.0-beta.22

### DIFF
--- a/.holo/lenses/slate-cbl-admin.toml
+++ b/.holo/lenses/slate-cbl-admin.toml
@@ -7,9 +7,12 @@ pkg = "slate-cbl-admin"
 [hololens.input]
 root = "sencha-workspace"
 files = [
-    "workspace.json",
+    "packages/slate-cbl-admin/**",
+    "packages/slate-core-data/**",
+    "packages/emergence-apikit/**",
+    "packages/jarvus-apikit/**",
     "ext/**",
-    "packages/**",
+    "workspace.json",
 ]
 
 [hololens.output]

--- a/.holo/lenses/slate-demos-student.toml
+++ b/.holo/lenses/slate-demos-student.toml
@@ -7,10 +7,21 @@ app = "SlateDemonstrationsStudent"
 [hololens.input]
 root = "sencha-workspace"
 files = [
-    "workspace.json",
-    "ext/**",
-    "packages/**",
     "SlateDemonstrationsStudent/**",
+    "packages/jarvus-routing/**",
+    "packages/slate-theme/**",
+    "packages/slate-cbl/**",
+    "packages/slate-cbl-colors/**",
+    "packages/slate-core-data/**",
+    "packages/slate-ui-classic/**",
+    "packages/emergence-apikit/**",
+    "packages/jarvus-apikit/**",
+    "packages/jarvus-ext-glyphs/**",
+    "packages/jarvus-ext-actionevents/**",
+    "packages/jarvus-lazydata/**",
+    "packages/jarvus-hotfixes/**",
+    "ext/**",
+    "workspace.json",
 ]
 
 [hololens.output]

--- a/.holo/lenses/slate-demos-teacher.toml
+++ b/.holo/lenses/slate-demos-teacher.toml
@@ -7,10 +7,21 @@ app = "SlateDemonstrationsTeacher"
 [hololens.input]
 root = "sencha-workspace"
 files = [
-    "workspace.json",
-    "ext/**",
-    "packages/**",
     "SlateDemonstrationsTeacher/**",
+    "packages/jarvus-routing/**",
+    "packages/slate-theme/**",
+    "packages/slate-cbl/**",
+    "packages/slate-cbl-colors/**",
+    "packages/slate-core-data/**",
+    "packages/slate-ui-classic/**",
+    "packages/emergence-apikit/**",
+    "packages/jarvus-apikit/**",
+    "packages/jarvus-ext-glyphs/**",
+    "packages/jarvus-ext-actionevents/**",
+    "packages/jarvus-lazydata/**",
+    "packages/jarvus-hotfixes/**",
+    "ext/**",
+    "workspace.json",
 ]
 
 [hololens.output]

--- a/.holo/lenses/slate-enroll-admin.toml
+++ b/.holo/lenses/slate-enroll-admin.toml
@@ -7,10 +7,22 @@ app = "SlateStudentCompetenciesAdmin"
 [hololens.input]
 root = "sencha-workspace"
 files = [
-    "workspace.json",
-    "ext/**",
-    "packages/**",
     "SlateStudentCompetenciesAdmin/**",
+    "packages/jarvus-routing/**",
+    "packages/slate-theme/**",
+    "packages/slate-cbl/**",
+    "packages/slate-cbl-colors/**",
+    "packages/slate-core-data/**",
+    "packages/slate-ui-classic/**",
+    "packages/emergence-apikit/**",
+    "packages/jarvus-apikit/**",
+    "packages/jarvus-ext-glyphs/**",
+    "packages/jarvus-ext-actionevents/**",
+    "packages/jarvus-lazydata/**",
+    "packages/jarvus-aggregrid/**",
+    "packages/jarvus-hotfixes/**",
+    "ext/**",
+    "workspace.json",
 ]
 
 [hololens.output]

--- a/.holo/lenses/slate-tasks-student.toml
+++ b/.holo/lenses/slate-tasks-student.toml
@@ -7,10 +7,21 @@ app = "SlateTasksStudent"
 [hololens.input]
 root = "sencha-workspace"
 files = [
-    "workspace.json",
-    "ext/**",
-    "packages/**",
     "SlateTasksStudent/**",
+    "packages/jarvus-routing/**",
+    "packages/slate-theme/**",
+    "packages/slate-cbl/**",
+    "packages/slate-cbl-colors/**",
+    "packages/slate-core-data/**",
+    "packages/slate-ui-classic/**",
+    "packages/emergence-apikit/**",
+    "packages/jarvus-apikit/**",
+    "packages/jarvus-ext-glyphs/**",
+    "packages/jarvus-ext-actionevents/**",
+    "packages/jarvus-lazydata/**",
+    "packages/jarvus-hotfixes/**",
+    "ext/**",
+    "workspace.json",
 ]
 
 [hololens.output]

--- a/.holo/lenses/slate-tasks-teacher.toml
+++ b/.holo/lenses/slate-tasks-teacher.toml
@@ -7,10 +7,22 @@ app = "SlateTasksTeacher"
 [hololens.input]
 root = "sencha-workspace"
 files = [
-    "workspace.json",
-    "ext/**",
-    "packages/**",
     "SlateTasksTeacher/**",
+    "packages/jarvus-routing/**",
+    "packages/slate-theme/**",
+    "packages/slate-cbl/**",
+    "packages/slate-cbl-colors/**",
+    "packages/slate-core-data/**",
+    "packages/slate-ui-classic/**",
+    "packages/emergence-apikit/**",
+    "packages/jarvus-apikit/**",
+    "packages/jarvus-ext-glyphs/**",
+    "packages/jarvus-ext-actionevents/**",
+    "packages/jarvus-lazydata/**",
+    "packages/jarvus-aggregrid/**",
+    "packages/jarvus-hotfixes/**",
+    "ext/**",
+    "workspace.json",
 ]
 
 [hololens.output]

--- a/php-config/Git.config.d/slate-cbl.php
+++ b/php-config/Git.config.d/slate-cbl.php
@@ -5,6 +5,19 @@ Git::$repositories['slate-cbl'] = [
     'originBranch' => 'emergence/vfs-site/v3',
     'workingBranch' => 'emergence/vfs-site/v3',
     'trees' => [
-        '.' => '/'
+        'api-docs',
+        'content-blocks',
+        'data-exporters',
+        'dwoo-plugins',
+        'event-handlers',
+        'html-templates',
+        'php-classes',
+        'php-config',
+        'php-migrations',
+        'phpunit-tests',
+        'site-root',
+        'site-tasks',
+        'webapp-builds',
+        'webapp-plugin-builds'
     ]
 ];


### PR DESCRIPTION
- chore: use explicit roots list for legacy git mappings
- refactor: minimize package trees for sencha builds