### PR TITLE
Release: slate-cbl v3.0.0-beta.26

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -54,3 +54,7 @@
 	path = sencha-workspace/packages.remote/slate-ui-classic
 	url = https://github.com/SlateFoundation/slate-ui-classic.git
 	branch = master
+[submodule "cypress/fixtures/database"]
+	path = cypress/fixtures/database
+	url = https://github.com/SlateFoundation/slate-fixtures.git
+	branch = cbl/demo

--- a/.holo/branches/emergence-layer/_slate-cbl.toml
+++ b/.holo/branches/emergence-layer/_slate-cbl.toml
@@ -1,6 +1,7 @@
 [holomapping]
 files = [
     "*/**",
+    "!.github/",
     "!.vscode/",
     "!books/",
     "!cypress/",

--- a/.studiorc
+++ b/.studiorc
@@ -1,6 +1,7 @@
 #!/bin/bash
-hab pkg install emergence/studio chakijs/studio
-source "$(hab pkg path emergence/studio)/studio.sh"
+hab pkg install --channel="emergence-studio-0.6" emergence/studio/0.6
+source "$(hab pkg path emergence/studio/0.6)/studio.sh"
+hab pkg install chakijs/studio
 source "$(hab pkg path chakijs/studio)/studio.sh"
 
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,35 +9,35 @@
             "type": "chrome",
             "request": "launch",
             "webRoot": "${workspaceFolder}/sencha-workspace",
-            "url": "http://localhost:3901/SlateDemonstrationsStudent/?cache=1&apiHost=cbl-develop.dev01.slatepowered.net"
+            "url": "http://localhost:7081/SlateDemonstrationsStudent/?cache=1&apiHost=localhost:7080"
         },
         {
             "name": "Launch SlateDemonstrationsTeacher",
             "type": "chrome",
             "request": "launch",
             "webRoot": "${workspaceFolder}/sencha-workspace",
-            "url": "http://localhost:3901/SlateDemonstrationsTeacher/?cache=1&apiHost=cbl-develop.dev01.slatepowered.net"
+            "url": "http://localhost:7081/SlateDemonstrationsTeacher/?cache=1&apiHost=localhost:7080"
         },
         {
             "name": "Launch SlateTasksStudent",
             "type": "chrome",
             "request": "launch",
             "webRoot": "${workspaceFolder}/sencha-workspace",
-            "url": "http://localhost:3901/SlateTasksStudent/?cache=1&apiHost=cbl-develop.dev01.slatepowered.net"
+            "url": "http://localhost:7081/SlateTasksStudent/?cache=1&apiHost=localhost:7080"
         },
         {
             "name": "Launch SlateTasksTeacher",
             "type": "chrome",
             "request": "launch",
             "webRoot": "${workspaceFolder}/sencha-workspace",
-            "url": "http://localhost:3901/SlateTasksTeacher/?cache=1&apiHost=cbl-develop.dev01.slatepowered.net"
+            "url": "http://localhost:7081/SlateTasksTeacher/?cache=1&apiHost=localhost:7080"
         },
         {
             "name": "Launch SlateTasksManager",
             "type": "chrome",
             "request": "launch",
             "webRoot": "${workspaceFolder}/sencha-workspace",
-            "url": "http://localhost:3901/SlateTasksManager/?cache=1&apiHost=cbl-develop.dev01.slatepowered.net"
+            "url": "http://localhost:7081/SlateTasksManager/?cache=1&apiHost=localhost:7080"
         },
         {
             "name": "Attach to Chrome",
@@ -45,7 +45,7 @@
             "request": "attach",
             "port": 9222,
             "webRoot": "${workspaceFolder}/sencha-workspace",
-            "url": "http://localhost:3901"
+            "url": "http://localhost:7081"
         }
     ]
 }

--- a/books/slate-cbl/development/getting_started.md
+++ b/books/slate-cbl/development/getting_started.md
@@ -38,16 +38,16 @@
 
     If you're working in *Visual Studio Code*, just run the task `studio:launch` to open a configured and persistent studio. Otherwise you'll need to launch a Habitat studio manually from a terminal.
 
-    On Mac or Windows, the `HAB_DOCKER_OPTS` environment variable must be configured to pass additional options through to Docker to expose the development web server outside the studio container:
+    The `HAB_DOCKER_OPTS` environment variable must be configured to pass additional options through to Docker to expose the development web server outside the studio container:
 
     ```bash
-    export HAB_DOCKER_OPTS="-p 7080:7080 -p 7081:7081 -p 3306:3306"
+    export HAB_DOCKER_OPTS="-p 7080:7080 -p 7081:7081 -p 3306:3306 --name emergence-studio"
     ```
 
-    Then on any system, launch the studio with:
+    Then launch the studio (forcing Docker mode):
 
     ```bash
-    hab studio enter
+    hab studio enter -D
     ```
 
     Review the notes printed to your terminal at the end of the studio startup process for a list of all available studio commands.

--- a/books/slate-cbl/development/getting_started.md
+++ b/books/slate-cbl/development/getting_started.md
@@ -77,11 +77,7 @@
 1. Load fixture data into site database (optional)
 
     ```bash
-    # clone fixture branch into git-ignored .data/ directory
-    git clone -b cbl/demo https://github.com/SlateFoundation/slate-fixtures.git .data/fixtures
-
-    # load all .sql files from fixture
-    cat .data/fixtures/*.sql | load-sql -
+    cat cypress/fixtures/database/*.sql | load-sql -
     ```
 
     The standard fixture data includes the following users, all with passwords matching their usernames:

--- a/books/slate-cbl/development/getting_started.md
+++ b/books/slate-cbl/development/getting_started.md
@@ -78,7 +78,7 @@
 
     ```bash
     # clone fixture branch into git-ignored .data/ directory
-    git clone -b cbl/competencies https://github.com/SlateFoundation/slate-fixtures.git .data/fixtures
+    git clone -b cbl/demo https://github.com/SlateFoundation/slate-fixtures.git .data/fixtures
 
     # load all .sql files from fixture
     cat .data/fixtures/*.sql | load-sql -

--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,7 @@
 {
     "baseUrl": "http://localhost:7080",
     "env": {
+        "STUDIO_SSH": null,
         "STUDIO_CONTAINER": "emergence-studio"
     }
 }

--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,6 @@
 {
     "baseUrl": "http://localhost:7080",
     "env": {
-        "STUDIO_CONTAINER": "slate-cbl-studio"
+        "STUDIO_CONTAINER": "emergence-studio"
     }
 }

--- a/cypress/integration/login_admin.js
+++ b/cypress/integration/login_admin.js
@@ -11,7 +11,7 @@ describe('Admin login test', () => {
     });
 
     it('Should toggle login modal display', () => {
-        cy.visit('http://localhost:7080/');
+        cy.visit('/');
 
         // should be visible after Log In click
         cy.get('#login-modal').should('not.be.visible');
@@ -29,27 +29,8 @@ describe('Admin login test', () => {
         cy.get('#login-modal').should('not.be.visible');
     });
 
-    it('Should login via Modal', () => {
-        cy.visit('http://localhost:7080/');
-
-        cy.get('#login-modal').should('not.be.visible');
-        cy.contains('Log In').click();
-
-        cy.contains('#login-modal').should('not.have.attr', 'display');
-        cy.focused()
-            .should('have.attr', 'name', '_LOGIN[username]')
-            .type('admin')
-            .tab();
-
-        cy.focused()
-            .should('have.attr', 'name', '_LOGIN[password]')
-            .type('admin{enter}');
-
-        cy.location('pathname').should('eq', '/');
-    });
-
     it('Should show login error notification', () => {
-        cy.visit('http://localhost:7080/');
+        cy.visit('/');
 
         cy.get('#login-modal').should('not.be.visible');
         cy.contains('Log In').click();
@@ -66,5 +47,24 @@ describe('Admin login test', () => {
         cy.contains('Sorry!')
             .parents('div')
             .should('have.attr', 'class', 'notify error');
+    });
+
+    it('Should login via Modal', () => {
+        cy.visit('/');
+
+        cy.get('#login-modal').should('not.be.visible');
+        cy.contains('Log In').click();
+
+        cy.contains('#login-modal').should('not.have.attr', 'display');
+        cy.focused()
+            .should('have.attr', 'name', '_LOGIN[username]')
+            .type('admin')
+            .tab();
+
+        cy.focused()
+            .should('have.attr', 'name', '_LOGIN[password]')
+            .type('admin{enter}');
+
+        cy.location('pathname').should('eq', '/');
     });
 });

--- a/cypress/integration/login_admin.js
+++ b/cypress/integration/login_admin.js
@@ -2,12 +2,7 @@ describe('Admin login test', () => {
 
     // load sample database before tests
     before(() => {
-        const studioContainer = Cypress.env('STUDIO_CONTAINER');
-
-        if (studioContainer) {
-            cy.exec(`echo 'DROP DATABASE IF EXISTS \`default\`; CREATE DATABASE \`default\`;' | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1`);
-            cy.exec(`cat .data/fixtures/*.sql | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1 default`);
-        }
+        cy.resetDatabase();
     });
 
     it('Should toggle login modal display', () => {

--- a/cypress/integration/login_admin.js
+++ b/cypress/integration/login_admin.js
@@ -1,4 +1,15 @@
 describe('Admin login test', () => {
+
+    // load sample database before tests
+    before(() => {
+        const studioContainer = Cypress.env('STUDIO_CONTAINER');
+
+        if (studioContainer) {
+            cy.exec(`echo 'DROP DATABASE IF EXISTS \`default\`; CREATE DATABASE \`default\`;' | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1`);
+            cy.exec(`cat .data/fixtures/*.sql | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1 default`);
+        }
+    });
+
     it('Should toggle login modal display', () => {
         cy.visit('http://localhost:7080/');
 

--- a/cypress/integration/register.js
+++ b/cypress/integration/register.js
@@ -2,11 +2,7 @@ describe('Admin login test', () => {
 
     // reset database before tests
     before(() => {
-        const studioContainer = Cypress.env('STUDIO_CONTAINER');
-
-        if (studioContainer) {
-            cy.exec(`echo 'DROP DATABASE IF EXISTS \`default\`;' | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1`);
-        }
+        cy.dropDatabase();
     });
 
     it('Register and set up profile', () => {

--- a/cypress/integration/register.js
+++ b/cypress/integration/register.js
@@ -1,4 +1,4 @@
-describe('Admin login test', () => {
+describe('Registration and user profile test', () => {
 
     // reset database before tests
     before(() => {

--- a/cypress/integration/student_compentencies.js
+++ b/cypress/integration/student_compentencies.js
@@ -1,0 +1,61 @@
+describe('Teacher student competencies test', () => {
+
+    // load sample database before tests
+    before(() => {
+        cy.resetDatabase();
+    });
+
+    // authenticate as 'teacher' user
+    beforeEach(() => {
+        cy.loginAs('teacher');
+    });
+
+    it('View student competencies dashboard as teacher', () => {
+
+        // open student demonstrations dashboard
+        cy.visit('/cbl/dashboards/student-competencies/admin');
+
+        // verify teacher redirect
+        cy.location('hash').should('eq', '');
+
+        cy.get('.slate-appcontainer-bodyWrap .slate-placeholder')
+            .contains('Select a list of students and a content area to load enrollments dashboard');
+
+        cy.withExt().then(({Ext, extQuerySelector, extQuerySelectorAll}) => {
+
+            // get the 'Rubric' selector element
+            var rubricSelector = extQuerySelector('slate-cbl-contentareaselector');
+
+            // click the selector
+            cy.get('#' + rubricSelector.el.dom.id).click();
+
+            // verify and click first element of picker dropdown
+            cy.get('#' + rubricSelector.getPicker().id + ' .x-boundlist-item')
+                .contains('English Language Arts')
+                .click();
+
+            // verify hash updates
+            cy.location('hash').should('eq', '#ELA');
+
+            // get the 'Students' selector element
+            var studentSelector = extQuerySelector('slate-cbl-studentslistselector');
+
+            // click the selector
+            cy.get('#' + studentSelector.el.dom.id)
+                .click()
+                .focused()
+                .type('ELA');
+
+            // verify and click first element of picker dropdown
+            cy.get('#' + studentSelector.getPicker().id + ' .x-boundlist-item')
+                .contains('ELA-001')
+                .click();
+
+            // verify hash updates
+            cy.location('hash').should('eq', '#ELA/section:ELA-001');
+
+            // verify content loads
+            cy.get('.slate-studentcompetencies-admin-grid').contains('Student Slate');
+        });
+    });
+});

--- a/cypress/integration/student_demonstrations.js
+++ b/cypress/integration/student_demonstrations.js
@@ -20,10 +20,10 @@ describe('Student demonstrations test', () => {
         cy.get('.slate-appcontainer-bodyWrap .slate-placeholder ')
             .contains('Select a content area to load demonstrations dashboard');
 
-        cy.withExt().then((Ext) => {
+        cy.withExt().then(({Ext, extQuerySelector, extQuerySelectorAll}) => {
 
             // get the selector element
-            var selectorEl = Ext.ComponentQuery.query('slate-cbl-contentareaselector')[0];
+            var selectorEl = extQuerySelector('slate-cbl-contentareaselector');
 
             // click the selector
             cy.get('#' + selectorEl.el.dom.id).click();

--- a/cypress/integration/student_demonstrations.js
+++ b/cypress/integration/student_demonstrations.js
@@ -10,55 +10,49 @@ describe('Student demonstrations test', () => {
         }
     });
 
+    // authenticate as 'student' user
+    beforeEach(() => {
+        cy.visit('/');
+        cy.request({
+            method: 'POST',
+            url: '/login/?format=json',
+            form: true,
+            body: {
+                '_LOGIN[username]': 'student',
+                '_LOGIN[password]': 'student',
+                '_LOGIN[returnMethod]': 'POST'
+            }
+        });
+    });
+
     it('View single dempnstration rubric as student', () => {
 
-        // Open homepage and login as 'student' via modal
-        cy.visit('/');
-
-        cy.get('#login-modal').should('not.be.visible');
-        cy.contains('Log In').click();
-
-        cy.contains('#login-modal').should('not.have.attr', 'display');
-        cy.focused()
-            .should('have.attr', 'name', '_LOGIN[username]')
-            .type('student')
-            .tab();
-
-        cy.focused()
-            .should('have.attr', 'name', '_LOGIN[password]')
-            .type('student{enter}');
-
-        // Verify login sucessful
-        cy.location('pathname').should('eq', '/');
-        cy.get('.slate-omnibar ul.omnibar-items .omnibar-item:nth-child(5n) a').contains('Student');
-
-        // Open student demonstrations dashboard
+        // open student demonstrations dashboard
         cy.visit('/cbl/dashboards/demonstrations/student');
 
-        // Verify student redirect
+        // verify student redirect
         cy.location('hash').should('eq', '#me');
         cy.get('.slate-appcontainer-bodyWrap .slate-placeholder ')
             .contains('Select a content area to load demonstrations dashboard');
 
         cy.window().then((win) => {
 
-            // Get the selector element
+            // het the selector element
             var selectorEl = win.Ext.ComponentQuery.query('slate-cbl-contentareaselector')[0];
 
-            // Click the selector
+            // click the selector
             cy.get('#' + selectorEl.el.dom.id).click();
 
-            // Get the picker element
+            // get the picker element
             var pickerEl = selectorEl.getPicker();
 
-
-            // Verify and click first element of selector dropdown
+            // verify and click first element of selector dropdown
             cy.get('#' + pickerEl.id + ' li:first-child')
                 .contains('English Language Arts')
                 .click();
 
-            // Verify content loads
+            // verify content loads
             cy.get('.slate-demonstrations-student-competenciessummary span').contains('English Language Arts');
-        })
+        });
     });
 });

--- a/cypress/integration/student_demonstrations.js
+++ b/cypress/integration/student_demonstrations.js
@@ -23,13 +23,13 @@ describe('Student demonstrations test', () => {
         cy.withExt().then(({Ext, extQuerySelector, extQuerySelectorAll}) => {
 
             // get the selector element
-            var selectorEl = extQuerySelector('slate-cbl-contentareaselector');
+            var contentAreaSelector = extQuerySelector('slate-cbl-contentareaselector');
 
             // click the selector
-            cy.get('#' + selectorEl.el.dom.id).click();
+            cy.get('#' + contentAreaSelector.el.dom.id).click();
 
             // verify and click first element of picker dropdown
-            cy.get('#' + selectorEl.getPicker().id + ' li:first-child')
+            cy.get('#' + contentAreaSelector.getPicker().id + ' li:first-child')
                 .contains('English Language Arts')
                 .click();
 

--- a/cypress/integration/student_demonstrations.js
+++ b/cypress/integration/student_demonstrations.js
@@ -37,17 +37,14 @@ describe('Student demonstrations test', () => {
 
         cy.window().then((win) => {
 
-            // het the selector element
+            // get the selector element
             var selectorEl = win.Ext.ComponentQuery.query('slate-cbl-contentareaselector')[0];
 
             // click the selector
             cy.get('#' + selectorEl.el.dom.id).click();
 
-            // get the picker element
-            var pickerEl = selectorEl.getPicker();
-
-            // verify and click first element of selector dropdown
-            cy.get('#' + pickerEl.id + ' li:first-child')
+            // verify and click first element of picker dropdown
+            cy.get('#' + selectorEl.getPicker().id + ' li:first-child')
                 .contains('English Language Arts')
                 .click();
 

--- a/cypress/integration/student_demonstrations.js
+++ b/cypress/integration/student_demonstrations.js
@@ -17,7 +17,7 @@ describe('Student demonstrations test', () => {
 
         // verify student redirect
         cy.location('hash').should('eq', '#me');
-        cy.get('.slate-appcontainer-bodyWrap .slate-placeholder ')
+        cy.get('.slate-appcontainer-bodyWrap .slate-placeholder')
             .contains('Select a content area to load demonstrations dashboard');
 
         cy.withExt().then(({Ext, extQuerySelector, extQuerySelectorAll}) => {

--- a/cypress/integration/student_demonstrations.js
+++ b/cypress/integration/student_demonstrations.js
@@ -2,12 +2,7 @@ describe('Student demonstrations test', () => {
 
     // load sample database before tests
     before(() => {
-        const studioContainer = Cypress.env('STUDIO_CONTAINER');
-
-        if (studioContainer) {
-            cy.exec(`echo 'DROP DATABASE IF EXISTS \`default\`; CREATE DATABASE \`default\`;' | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1`);
-            cy.exec(`cat .data/fixtures/*.sql | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1 default`);
-        }
+        cy.resetDatabase();
     });
 
     // authenticate as 'student' user

--- a/cypress/integration/student_demonstrations.js
+++ b/cypress/integration/student_demonstrations.js
@@ -25,7 +25,7 @@ describe('Student demonstrations test', () => {
         });
     });
 
-    it('View single dempnstration rubric as student', () => {
+    it('View single demonstration rubric as student', () => {
 
         // open student demonstrations dashboard
         cy.visit('/cbl/dashboards/demonstrations/student');

--- a/cypress/integration/student_demonstrations.js
+++ b/cypress/integration/student_demonstrations.js
@@ -20,10 +20,10 @@ describe('Student demonstrations test', () => {
         cy.get('.slate-appcontainer-bodyWrap .slate-placeholder ')
             .contains('Select a content area to load demonstrations dashboard');
 
-        cy.window().then((win) => {
+        cy.withExt().then((Ext) => {
 
             // get the selector element
-            var selectorEl = win.Ext.ComponentQuery.query('slate-cbl-contentareaselector')[0];
+            var selectorEl = Ext.ComponentQuery.query('slate-cbl-contentareaselector')[0];
 
             // click the selector
             cy.get('#' + selectorEl.el.dom.id).click();

--- a/cypress/integration/student_demonstrations.js
+++ b/cypress/integration/student_demonstrations.js
@@ -12,17 +12,7 @@ describe('Student demonstrations test', () => {
 
     // authenticate as 'student' user
     beforeEach(() => {
-        cy.visit('/');
-        cy.request({
-            method: 'POST',
-            url: '/login/?format=json',
-            form: true,
-            body: {
-                '_LOGIN[username]': 'student',
-                '_LOGIN[password]': 'student',
-                '_LOGIN[returnMethod]': 'POST'
-            }
-        });
+        cy.loginAs('student');
     });
 
     it('View single demonstration rubric as student', () => {

--- a/cypress/integration/student_demonstrations.js
+++ b/cypress/integration/student_demonstrations.js
@@ -1,0 +1,61 @@
+describe('Student demonstrations test', () => {
+
+    // load sample database before tests
+    before(() => {
+        const studioContainer = Cypress.env('STUDIO_CONTAINER');
+
+        if (studioContainer) {
+            cy.exec(`echo 'DROP DATABASE IF EXISTS \`default\`; CREATE DATABASE \`default\`;' | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1`);
+            cy.exec(`cat .data/fixtures/*.sql | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1 default`);
+        }
+    });
+
+    it('View single dempnstration rubric as student', () => {
+
+        // Open homepage and login as 'student' via modal
+        cy.visit('http://localhost:7080/');
+
+        cy.get('#login-modal').should('not.be.visible');
+        cy.contains('Log In').click();
+
+        cy.contains('#login-modal').should('not.have.attr', 'display');
+        cy.focused()
+            .should('have.attr', 'name', '_LOGIN[username]')
+            .type('student')
+            .tab();
+
+        cy.focused()
+            .should('have.attr', 'name', '_LOGIN[password]')
+            .type('student{enter}');
+
+        // Verify login sucessful
+        cy.location('pathname').should('eq', '/');
+        cy.get('.slate-omnibar ul.omnibar-items .omnibar-item:nth-child(5n) a').contains('Student');
+
+        // Open student demonstrations dashboard
+        cy.visit('http://localhost:7080/cbl/dashboards/demonstrations/student');
+
+        // Verify student redirect
+        cy.location('hash').should('eq', '#me');
+        cy.get('.slate-appcontainer-bodyWrap .slate-placeholder ')
+            .contains('Select a content area to load demonstrations dashboard');
+
+        // Click into 'Rubric' selector
+        cy.get('.slate-cbl-contentareaselector .x-form-arrow-trigger').then(($el) => {
+
+            // Get the id of the core selector element
+            var selectorId = $el[0].id.replace('-trigger-picker', '');
+
+            // Open the selector
+            $el.click();
+
+            // Verify and click first element of selector dropdown
+            cy.get('#' + selectorId + '-picker-listEl li:first-child')
+                .contains('English Language Arts')
+                .click();
+
+            // Verify content loads
+            cy.get('.slate-demonstrations-student-competenciessummary span').contains('English Language Arts');
+        });
+    });
+});

--- a/cypress/integration/student_demonstrations.js
+++ b/cypress/integration/student_demonstrations.js
@@ -13,7 +13,7 @@ describe('Student demonstrations test', () => {
     it('View single dempnstration rubric as student', () => {
 
         // Open homepage and login as 'student' via modal
-        cy.visit('http://localhost:7080/');
+        cy.visit('/');
 
         cy.get('#login-modal').should('not.be.visible');
         cy.contains('Log In').click();
@@ -33,29 +33,32 @@ describe('Student demonstrations test', () => {
         cy.get('.slate-omnibar ul.omnibar-items .omnibar-item:nth-child(5n) a').contains('Student');
 
         // Open student demonstrations dashboard
-        cy.visit('http://localhost:7080/cbl/dashboards/demonstrations/student');
+        cy.visit('/cbl/dashboards/demonstrations/student');
 
         // Verify student redirect
         cy.location('hash').should('eq', '#me');
         cy.get('.slate-appcontainer-bodyWrap .slate-placeholder ')
             .contains('Select a content area to load demonstrations dashboard');
 
-        // Click into 'Rubric' selector
-        cy.get('.slate-cbl-contentareaselector .x-form-arrow-trigger').then(($el) => {
+        cy.window().then((win) => {
 
-            // Get the id of the core selector element
-            var selectorId = $el[0].id.replace('-trigger-picker', '');
+            // Get the selector element
+            var selectorEl = win.Ext.ComponentQuery.query('slate-cbl-contentareaselector')[0];
 
-            // Open the selector
-            $el.click();
+            // Click the selector
+            cy.get('#' + selectorEl.el.dom.id).click();
+
+            // Get the picker element
+            var pickerEl = selectorEl.getPicker();
+
 
             // Verify and click first element of selector dropdown
-            cy.get('#' + selectorId + '-picker-listEl li:first-child')
+            cy.get('#' + pickerEl.id + ' li:first-child')
                 .contains('English Language Arts')
                 .click();
 
             // Verify content loads
             cy.get('.slate-demonstrations-student-competenciessummary span').contains('English Language Arts');
-        });
+        })
     });
 });

--- a/cypress/integration/student_demonstrations_growth.js
+++ b/cypress/integration/student_demonstrations_growth.js
@@ -1,0 +1,79 @@
+describe('Student competency growth calculation test', () => {
+
+    // load sample database before tests
+    before(() => {
+        cy.resetDatabase();
+    });
+
+    // authenticate as 'teacher' user
+    beforeEach(() => {
+        cy.loginAs('teacher');
+    });
+
+    it('View sample students progress', () => {
+
+        // open student demonstrations dashboard
+        cy.visit('/cbl/dashboards/demonstrations/student#student/ELA');
+
+        // verify teacher redirect
+        cy.get('.slate-demonstrations-student-competenciessummary .slate-simplepanel-title')
+            .contains('English Language Arts');
+
+        cy.withExt().then(({Ext, extQuerySelector, extQuerySelectorAll}) => {
+
+            // validate section overview metrics
+            var competencySummaryCardId = '.slate-demonstrations-student-competenciessummary';
+
+            cy.get(competencySummaryCardId)
+                .find('div[data-ref="meterPercentEl"]')
+                .contains('74%');
+
+            cy.get(competencySummaryCardId)
+                .find('td[data-ref="missedEl"]')
+                .contains('0');
+
+            cy.get(competencySummaryCardId)
+                .find('td[data-ref="averageEl"]')
+                .contains('10');
+
+            cy.get(competencySummaryCardId)
+                .find('td[data-ref="growthEl"]')
+                .contains('1.3 yr');
+
+            // TODO: fix component query to select card by competency id
+            var studentCompetencyCards = extQuerySelectorAll('slate-demonstrations-student-competencycard');
+
+            // validate the growth calculation for each card
+            studentCompetencyCards.forEach(function(competencyCard) {
+
+                // TODO - add support for additional cards
+                if (competencyCard.competency.id != 6) {
+                    return;
+                }
+
+                var competencyCardId = '#' + competencyCard.id;
+
+                // check baseline rating calculation
+                cy.get(competencyCardId)
+                    .find('span[data-ref="codeEl"]')
+                    .contains('ELA.6');
+
+                cy.get(competencyCardId)
+                    .find('td[data-ref="baselineRatingEl"]')
+                    .contains('9.5');
+
+                cy.get(competencyCardId)
+                    .find('td[data-ref="averageEl"]')
+                    .contains('10');
+
+                cy.get(competencyCardId)
+                    .find('td[data-ref="growthEl"]')
+                    .contains('1.5 yr');
+
+                cy.get(competencyCardId)
+                    .find('div[data-ref="meterPercentEl"]')
+                    .contains('67%');
+            });
+        });
+    });
+});

--- a/cypress/integration/student_demonstrations_growth.js
+++ b/cypress/integration/student_demonstrations_growth.js
@@ -40,40 +40,30 @@ describe('Student competency growth calculation test', () => {
                 .find('td[data-ref="growthEl"]')
                 .contains('1.3 yr');
 
-            // TODO: fix component query to select card by competency id
-            var studentCompetencyCards = extQuerySelectorAll('slate-demonstrations-student-competencycard');
+            // validate ELA.6 metrics
+            var competencyCard = extQuerySelector('slate-demonstrations-student-competencycard{getCompetency().get("Code")=="ELA.6"}');
+            var competencyCardId = '#' + competencyCard.id;
 
-            // validate the growth calculation for each card
-            studentCompetencyCards.forEach(function(competencyCard) {
+            // check baseline rating calculation
+            cy.get(competencyCardId)
+                .find('span[data-ref="codeEl"]')
+                .contains('ELA.6');
 
-                // TODO - add support for additional cards
-                if (competencyCard.competency.id != 6) {
-                    return;
-                }
+            cy.get(competencyCardId)
+                .find('td[data-ref="baselineRatingEl"]')
+                .contains('9.5');
 
-                var competencyCardId = '#' + competencyCard.id;
+            cy.get(competencyCardId)
+                .find('td[data-ref="averageEl"]')
+                .contains('10');
 
-                // check baseline rating calculation
-                cy.get(competencyCardId)
-                    .find('span[data-ref="codeEl"]')
-                    .contains('ELA.6');
+            cy.get(competencyCardId)
+                .find('td[data-ref="growthEl"]')
+                .contains('1.5 yr');
 
-                cy.get(competencyCardId)
-                    .find('td[data-ref="baselineRatingEl"]')
-                    .contains('9.5');
-
-                cy.get(competencyCardId)
-                    .find('td[data-ref="averageEl"]')
-                    .contains('10');
-
-                cy.get(competencyCardId)
-                    .find('td[data-ref="growthEl"]')
-                    .contains('1.5 yr');
-
-                cy.get(competencyCardId)
-                    .find('div[data-ref="meterPercentEl"]')
-                    .contains('67%');
-            });
+            cy.get(competencyCardId)
+                .find('div[data-ref="meterPercentEl"]')
+                .contains('67%');
         });
     });
 });

--- a/cypress/integration/student_tasks.js
+++ b/cypress/integration/student_tasks.js
@@ -18,6 +18,32 @@ describe('Student tasks test', () => {
         // verify student redirect
         cy.location('hash').should('eq', '#me/all');
 
-        // TODO - check for page content
+        cy.withExt().then(({Ext, extQuerySelector, extQuerySelectorAll}) => {
+
+            // get current tasks list
+            var currentTasksTree = extQuerySelector('slate-tasks-student-tasktree');
+
+            // verify content has finished loading
+            cy.get('#' + currentTasksTree.id)
+                .contains('ELA Task One')
+
+            // get the course section element
+            var courseSectionSelector = extQuerySelector('slate-cbl-sectionselector');
+
+            // click the selector
+            cy.get('#' + courseSectionSelector.el.dom.id).click();
+
+            // click ELA Studio element of picker dropdown
+            cy.get('#' + courseSectionSelector.getPicker().id + ' .x-boundlist-item')
+                .contains('ELA Studio')
+                .click();
+
+            // verify hash
+            cy.location('hash').should('eq', '#me/ELA-001');
+
+            // verify content loads
+            cy.get('#' + currentTasksTree.id)
+                .contains('ELA Task One')
+        });
     });
 });

--- a/cypress/integration/student_tasks.js
+++ b/cypress/integration/student_tasks.js
@@ -2,12 +2,7 @@ describe('Student tasks test', () => {
 
     // load sample database before tests
     before(() => {
-        const studioContainer = Cypress.env('STUDIO_CONTAINER');
-
-        if (studioContainer) {
-            cy.exec(`echo 'DROP DATABASE IF EXISTS \`default\`; CREATE DATABASE \`default\`;' | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1`);
-            cy.exec(`cat .data/fixtures/*.sql | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1 default`);
-        }
+        cy.resetDatabase();
     });
 
     // authenticate as 'student' user

--- a/cypress/integration/student_tasks.js
+++ b/cypress/integration/student_tasks.js
@@ -1,0 +1,38 @@
+describe('Student tasks test', () => {
+
+    // load sample database before tests
+    before(() => {
+        const studioContainer = Cypress.env('STUDIO_CONTAINER');
+
+        if (studioContainer) {
+            cy.exec(`echo 'DROP DATABASE IF EXISTS \`default\`; CREATE DATABASE \`default\`;' | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1`);
+            cy.exec(`cat .data/fixtures/*.sql | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1 default`);
+        }
+    });
+
+    // authenticate as 'student' user
+    beforeEach(() => {
+        cy.visit('/');
+        cy.request({
+            method: 'POST',
+            url: '/login/?format=json',
+            form: true,
+            body: {
+                '_LOGIN[username]': 'student',
+                '_LOGIN[password]': 'student',
+                '_LOGIN[returnMethod]': 'POST'
+            }
+        });
+    });
+
+    it('View single task as student', () => {
+
+        // open student demonstrations dashboard
+        cy.visit('/cbl/dashboards/tasks/student');
+
+        // verify student redirect
+        cy.location('hash').should('eq', '#me/all');
+
+        // TODO - check for page content
+    });
+});

--- a/cypress/integration/student_tasks.js
+++ b/cypress/integration/student_tasks.js
@@ -12,17 +12,7 @@ describe('Student tasks test', () => {
 
     // authenticate as 'student' user
     beforeEach(() => {
-        cy.visit('/');
-        cy.request({
-            method: 'POST',
-            url: '/login/?format=json',
-            form: true,
-            body: {
-                '_LOGIN[username]': 'student',
-                '_LOGIN[password]': 'student',
-                '_LOGIN[returnMethod]': 'POST'
-            }
-        });
+        cy.loginAs('student');
     });
 
     it('View single task as student', () => {

--- a/cypress/integration/student_tasks_competency_rating.js
+++ b/cypress/integration/student_tasks_competency_rating.js
@@ -1,0 +1,37 @@
+describe('Student tasks demonstrations competency rating level test', () => {
+
+    // load sample database before tests
+    before(() => {
+        cy.resetDatabase();
+    });
+
+    // authenticate as 'teacher' user
+    beforeEach(() => {
+        cy.loginAs('teacher');
+    });
+
+    it('View single tasks as teacher', () => {
+
+        // open student demonstrations dashboard
+        cy.visit('/cbl/dashboards/tasks/teacher#ELA-001/all');
+
+        // wait for grid container to load
+        cy.get('.slate-appcontainer').contains('ELA Task One');
+
+        cy.withExt().then(({Ext, extQuerySelector, extQuerySelectorAll}) => {
+
+            // find teh student's grid
+            var studentsGrid = extQuerySelector('slate-studentsgrid');
+
+            // find and click the first grid cell
+            cy.get('#' + studentsGrid.el.dom.id + ' .slate-studentsgrid-cell')
+                .first()
+                .click();
+
+            // ensure the first skill rating field has class 'cbl-level-9'
+            cy.get('.slate-cbl-skillratingsfield .slate-cbl-ratings-slider')
+                .first()
+                .should('have.have.class', 'cbl-level-9')
+        });
+    });
+});

--- a/cypress/integration/teacher_demonstrations.js
+++ b/cypress/integration/teacher_demonstrations.js
@@ -22,19 +22,39 @@ describe('Teacher demonstrations test', () => {
 
         cy.withExt().then(({Ext, extQuerySelector, extQuerySelectorAll}) => {
 
-            // get the selector element
-            var contentAreaSelector = extQuerySelector('slate-cbl-contentareaselector');
+            // get the 'Rubric' selector element
+            var rubricSelector = extQuerySelector('slate-cbl-contentareaselector');
 
             // click the selector
-            cy.get('#' + contentAreaSelector.el.dom.id).click();
+            cy.get('#' + rubricSelector.el.dom.id).click();
 
             // verify and click first element of picker dropdown
-            cy.get('#' + contentAreaSelector.getPicker().id + ' li:first-child')
+            cy.get('#' + rubricSelector.getPicker().id + ' .x-boundlist-item')
                 .contains('English Language Arts')
                 .click();
 
+            // verify hash updates
+            cy.location('hash').should('eq', '#ELA');
+
+            // get the 'Students' selector element
+            var studentSelector = extQuerySelector('slate-cbl-studentslistselector');
+
+            // click the selector
+            cy.get('#' + studentSelector.el.dom.id)
+                .click()
+                .focused()
+                .type('ELA');
+
+            // verify and click first element of picker dropdown
+            cy.get('#' + studentSelector.getPicker().id + ' .x-boundlist-item')
+                .contains('ELA-001')
+                .click();
+
+            // verify hash updates
+            cy.location('hash').should('eq', '#ELA/section:ELA-001');
+
             // verify content loads
-            cy.get('.slate-demonstrations-student-competenciessummary span').contains('English Language Arts');
+            cy.get('.cbl-grid-competencies').contains('Reading Critically');
         });
     });
 });

--- a/cypress/integration/teacher_demonstrations.js
+++ b/cypress/integration/teacher_demonstrations.js
@@ -10,22 +10,12 @@ describe('Teacher demonstrations test', () => {
         }
     });
 
-    // authenticate as 'student' user
+    // authenticate as 'teacher' user
     beforeEach(() => {
-        cy.visit('/');
-        cy.request({
-            method: 'POST',
-            url: '/login/?format=json',
-            form: true,
-            body: {
-                '_LOGIN[username]': 'teacher',
-                '_LOGIN[password]': 'teacher',
-                '_LOGIN[returnMethod]': 'POST'
-            }
-        });
+        cy.loginAs('teacher');
     });
 
-    it('View single demonstration rubric as student', () => {
+    it('View single demonstration rubric as teacher', () => {
 
         // open student demonstrations dashboard
         cy.visit('/cbl/dashboards/demonstrations/teacher');

--- a/cypress/integration/teacher_demonstrations.js
+++ b/cypress/integration/teacher_demonstrations.js
@@ -2,12 +2,7 @@ describe('Teacher demonstrations test', () => {
 
     // load sample database before tests
     before(() => {
-        const studioContainer = Cypress.env('STUDIO_CONTAINER');
-
-        if (studioContainer) {
-            cy.exec(`echo 'DROP DATABASE IF EXISTS \`default\`; CREATE DATABASE \`default\`;' | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1`);
-            cy.exec(`cat .data/fixtures/*.sql | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1 default`);
-        }
+        cy.resetDatabase();
     });
 
     // authenticate as 'teacher' user

--- a/cypress/integration/teacher_demonstrations.js
+++ b/cypress/integration/teacher_demonstrations.js
@@ -20,10 +20,10 @@ describe('Teacher demonstrations test', () => {
         cy.get('.slate-appcontainer-bodyWrap .slate-placeholder ')
             .contains('Select a list of students and a content area to load progress dashboard');
 
-        cy.window().then((win) => {
+        cy.withExt().then(({Ext, extQuerySelector, extQuerySelectorAll}) => {
 
             // get the selector element
-            var selectorEl = win.Ext.ComponentQuery.query('slate-cbl-contentareaselector')[0];
+            var selectorEl = extQuerySelector('slate-cbl-contentareaselector');
 
             // click the selector
             cy.get('#' + selectorEl.el.dom.id).click();

--- a/cypress/integration/teacher_demonstrations.js
+++ b/cypress/integration/teacher_demonstrations.js
@@ -1,0 +1,55 @@
+describe('Teacher demonstrations test', () => {
+
+    // load sample database before tests
+    before(() => {
+        const studioContainer = Cypress.env('STUDIO_CONTAINER');
+
+        if (studioContainer) {
+            cy.exec(`echo 'DROP DATABASE IF EXISTS \`default\`; CREATE DATABASE \`default\`;' | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1`);
+            cy.exec(`cat .data/fixtures/*.sql | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1 default`);
+        }
+    });
+
+    // authenticate as 'student' user
+    beforeEach(() => {
+        cy.visit('/');
+        cy.request({
+            method: 'POST',
+            url: '/login/?format=json',
+            form: true,
+            body: {
+                '_LOGIN[username]': 'teacher',
+                '_LOGIN[password]': 'teacher',
+                '_LOGIN[returnMethod]': 'POST'
+            }
+        });
+    });
+
+    it('View single demonstration rubric as student', () => {
+
+        // open student demonstrations dashboard
+        cy.visit('/cbl/dashboards/demonstrations/teacher');
+
+        // verify teacher redirect
+        cy.location('hash').should('eq', '#_');
+        cy.get('.slate-appcontainer-bodyWrap .slate-placeholder ')
+            .contains('Select a list of students and a content area to load progress dashboard');
+
+        cy.window().then((win) => {
+
+            // get the selector element
+            var selectorEl = win.Ext.ComponentQuery.query('slate-cbl-contentareaselector')[0];
+
+            // click the selector
+            cy.get('#' + selectorEl.el.dom.id).click();
+
+            // verify and click first element of picker dropdown
+            cy.get('#' + selectorEl.getPicker().id + ' li:first-child')
+                .contains('English Language Arts')
+                .click();
+
+            // verify content loads
+            cy.get('.slate-demonstrations-student-competenciessummary span').contains('English Language Arts');
+        });
+    });
+});

--- a/cypress/integration/teacher_demonstrations.js
+++ b/cypress/integration/teacher_demonstrations.js
@@ -23,13 +23,13 @@ describe('Teacher demonstrations test', () => {
         cy.withExt().then(({Ext, extQuerySelector, extQuerySelectorAll}) => {
 
             // get the selector element
-            var selectorEl = extQuerySelector('slate-cbl-contentareaselector');
+            var contentAreaSelector = extQuerySelector('slate-cbl-contentareaselector');
 
             // click the selector
-            cy.get('#' + selectorEl.el.dom.id).click();
+            cy.get('#' + contentAreaSelector.el.dom.id).click();
 
             // verify and click first element of picker dropdown
-            cy.get('#' + selectorEl.getPicker().id + ' li:first-child')
+            cy.get('#' + contentAreaSelector.getPicker().id + ' li:first-child')
                 .contains('English Language Arts')
                 .click();
 

--- a/cypress/integration/teacher_tasks.js
+++ b/cypress/integration/teacher_tasks.js
@@ -2,12 +2,7 @@ describe('Teacher demonstrations test', () => {
 
     // load sample database before tests
     before(() => {
-        const studioContainer = Cypress.env('STUDIO_CONTAINER');
-
-        if (studioContainer) {
-            cy.exec(`echo 'DROP DATABASE IF EXISTS \`default\`; CREATE DATABASE \`default\`;' | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1`);
-            cy.exec(`cat .data/fixtures/*.sql | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1 default`);
-        }
+        cy.resetDatabase();
     });
 
     // authenticate as 'teacher' user

--- a/cypress/integration/teacher_tasks.js
+++ b/cypress/integration/teacher_tasks.js
@@ -29,7 +29,7 @@ describe('Teacher demonstrations test', () => {
             // click the selector
             cy.get('#' + sectionSelector.el.dom.id).click();
 
-            // click ELA Studeio element of picker dropdown
+            // click ELA Studio element of picker dropdown
             cy.get('#' + sectionSelector.getPicker().id + ' .x-boundlist-item')
                 .contains('ELA Studio')
                 .click();

--- a/cypress/integration/teacher_tasks.js
+++ b/cypress/integration/teacher_tasks.js
@@ -29,14 +29,17 @@ describe('Teacher demonstrations test', () => {
             // click the selector
             cy.get('#' + sectionSelector.el.dom.id).click();
 
-            // verify and click first element of picker dropdown
+            // click ELA Studeio element of picker dropdown
             cy.get('#' + sectionSelector.getPicker().id + ' .x-boundlist-item')
-                .contains('Math Studio')
+                .contains('ELA Studio')
                 .click();
+
+            // verify hash
+            cy.location('hash').should('eq', '#ELA-001/all');
 
             // verify content loads
             var studentGrid = extQuerySelector('slate-studentsgrid');
-            cy.get('#' + studentGrid.el.dom.id).contains('Student Slate');
+            cy.get('#' + studentGrid.el.dom.id).contains('ELA Task One');
         });
     });
 });

--- a/cypress/integration/teacher_tasks.js
+++ b/cypress/integration/teacher_tasks.js
@@ -1,0 +1,38 @@
+describe('Teacher demonstrations test', () => {
+
+    // load sample database before tests
+    before(() => {
+        const studioContainer = Cypress.env('STUDIO_CONTAINER');
+
+        if (studioContainer) {
+            cy.exec(`echo 'DROP DATABASE IF EXISTS \`default\`; CREATE DATABASE \`default\`;' | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1`);
+            cy.exec(`cat .data/fixtures/*.sql | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1 default`);
+        }
+    });
+
+    // authenticate as 'student' user
+    beforeEach(() => {
+        cy.visit('/');
+        cy.request({
+            method: 'POST',
+            url: '/login/?format=json',
+            form: true,
+            body: {
+                '_LOGIN[username]': 'teacher',
+                '_LOGIN[password]': 'teacher',
+                '_LOGIN[returnMethod]': 'POST'
+            }
+        });
+    });
+
+    it('View single tasks as teacher', () => {
+
+        // open student demonstrations dashboard
+        cy.visit('/cbl/dashboards/tasks/teacher');
+
+        // verify teacher redirect
+        cy.location('hash').should('eq', '');
+
+        // TODO - check for page content
+    });
+});

--- a/cypress/integration/teacher_tasks.js
+++ b/cypress/integration/teacher_tasks.js
@@ -10,19 +10,9 @@ describe('Teacher demonstrations test', () => {
         }
     });
 
-    // authenticate as 'student' user
+    // authenticate as 'teacher' user
     beforeEach(() => {
-        cy.visit('/');
-        cy.request({
-            method: 'POST',
-            url: '/login/?format=json',
-            form: true,
-            body: {
-                '_LOGIN[username]': 'teacher',
-                '_LOGIN[password]': 'teacher',
-                '_LOGIN[returnMethod]': 'POST'
-            }
-        });
+        cy.loginAs('teacher');
     });
 
     it('View single tasks as teacher', () => {

--- a/cypress/integration/teacher_tasks.js
+++ b/cypress/integration/teacher_tasks.js
@@ -18,6 +18,25 @@ describe('Teacher demonstrations test', () => {
         // verify teacher redirect
         cy.location('hash').should('eq', '');
 
-        // TODO - check for page content
+        cy.get('.slate-appcontainer-bodyWrap .slate-placeholder')
+            .contains('Select a section to load tasks dashboard');
+
+        cy.withExt().then(({Ext, extQuerySelector, extQuerySelectorAll}) => {
+
+            // get the selector element
+            var sectionSelector = extQuerySelector('slate-cbl-sectionselector');
+
+            // click the selector
+            cy.get('#' + sectionSelector.el.dom.id).click();
+
+            // verify and click first element of picker dropdown
+            cy.get('#' + sectionSelector.getPicker().id + ' .x-boundlist-item')
+                .contains('Math Studio')
+                .click();
+
+            // verify content loads
+            var studentGrid = extQuerySelector('slate-studentsgrid');
+            cy.get('#' + studentGrid.el.dom.id).contains('Student Slate');
+        });
     });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -53,3 +53,27 @@ Cypress.Commands.add('loginAs', (user) => {
       }
   });
 });
+
+// Drop and load database in one step
+Cypress.Commands.add('resetDatabase', () => {
+  cy.dropDatabase();
+  cy.loadDatabase();
+});
+
+// Drops the entire
+Cypress.Commands.add('dropDatabase', () => {
+  const studioContainer = Cypress.env('STUDIO_CONTAINER');
+
+  if (studioContainer) {
+      cy.exec(`echo 'DROP DATABASE IF EXISTS \`default\`; CREATE DATABASE \`default\`;' | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1`);
+  }
+});
+
+// Reload the original data fixtures
+Cypress.Commands.add('loadDatabase', () => {
+  const studioContainer = Cypress.env('STUDIO_CONTAINER');
+
+  if (studioContainer) {
+    cy.exec(`cat .data/fixtures/*.sql | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1 default`);
+  }
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -65,7 +65,7 @@ Cypress.Commands.add('dropDatabase', () => {
   const studioContainer = Cypress.env('STUDIO_CONTAINER');
 
   if (studioContainer) {
-      cy.exec(`echo 'DROP DATABASE IF EXISTS \`default\`; CREATE DATABASE IF NOT EXISTS \`default\`;' | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1`);
+      cy.exec(`echo 'DROP DATABASE IF EXISTS \`default\`; CREATE DATABASE \`default\`;' | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1`);
   }
 });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -65,7 +65,7 @@ Cypress.Commands.add('dropDatabase', () => {
   const studioContainer = Cypress.env('STUDIO_CONTAINER');
 
   if (studioContainer) {
-      cy.exec(`echo 'DROP DATABASE IF EXISTS \`default\`; CREATE DATABASE \`default\`;' | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1`);
+      cy.exec(`echo 'DROP DATABASE IF EXISTS \`default\`; CREATE DATABASE IF NOT EXISTS \`default\`;' | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1`);
   }
 });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -38,3 +38,18 @@ Cypress.Commands.add('upload_file', (fileName, fileType = ' ', selector) => {
         })
     })
   })
+
+// Login command
+Cypress.Commands.add('loginAs', (user) => {
+  cy.visit('/');
+  cy.request({
+      method: 'POST',
+      url: '/login/?format=json',
+      form: true,
+      body: {
+          '_LOGIN[username]': user,
+          '_LOGIN[password]': user,
+          '_LOGIN[returnMethod]': 'POST'
+      }
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -63,18 +63,26 @@ Cypress.Commands.add('resetDatabase', () => {
 // Drops the entire
 Cypress.Commands.add('dropDatabase', () => {
   const studioContainer = Cypress.env('STUDIO_CONTAINER');
+  const studioSSH = Cypress.env('STUDIO_SSH');
+  const studioDocker = studioSSH
+    ? `ssh ${studioSSH} docker`
+    : 'docker'
 
   if (studioContainer) {
-      cy.exec(`echo 'DROP DATABASE IF EXISTS \`default\`; CREATE DATABASE \`default\`;' | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1`);
+      cy.exec(`echo 'DROP DATABASE IF EXISTS \`default\`; CREATE DATABASE \`default\`;' | ${studioDocker} exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1`);
   }
 });
 
 // Reload the original data fixtures
 Cypress.Commands.add('loadDatabase', () => {
   const studioContainer = Cypress.env('STUDIO_CONTAINER');
+  const studioSSH = Cypress.env('STUDIO_SSH');
+  const studioDocker = studioSSH
+    ? `ssh ${studioSSH} docker`
+    : 'docker'
 
   if (studioContainer) {
-    cy.exec(`cat cypress/fixtures/database/*.sql | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1 default`);
+    cy.exec(`cat cypress/fixtures/database/*.sql | ${studioDocker} exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1 default`);
   }
 });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -81,6 +81,11 @@ Cypress.Commands.add('loadDatabase', () => {
 // Ext command getter
 Cypress.Commands.add('withExt', () => {
   cy.window().then((win) => {
-    return win.Ext;
+    const Ext = win.Ext;
+    return {
+      Ext: win.Ext,
+      extQuerySelector: query => Ext.ComponentQuery.query(query)[0],
+      extQuerySelectorAll: query => Ext.ComponentQuery.query(query)
+    };
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -77,3 +77,10 @@ Cypress.Commands.add('loadDatabase', () => {
     cy.exec(`cat .data/fixtures/*.sql | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1 default`);
   }
 });
+
+// Ext command getter
+Cypress.Commands.add('withExt', () => {
+  cy.window().then((win) => {
+    return win.Ext;
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -74,7 +74,7 @@ Cypress.Commands.add('loadDatabase', () => {
   const studioContainer = Cypress.env('STUDIO_CONTAINER');
 
   if (studioContainer) {
-    cy.exec(`cat .data/fixtures/*.sql | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1 default`);
+    cy.exec(`cat cypress/fixtures/database/*.sql | docker exec -i ${studioContainer} hab pkg exec core/mysql mysql -u root -h 127.0.0.1 default`);
   }
 });
 

--- a/site-root/cbl/powertools/review-incomplete-graduations.php
+++ b/site-root/cbl/powertools/review-incomplete-graduations.php
@@ -53,54 +53,54 @@ $graduations = Slate\CBL\StudentCompetency::getAllByQuery(
     </thead>
 
     <tbody>
-        <?php foreach ($graduations as $StudentCompetency): ?>
-        <?php
-        $previous = Slate\CBL\StudentCompetency::getAllByWhere([
-            'StudentID' => $StudentCompetency->StudentID,
-            'CompetencyID' => $StudentCompetency->CompetencyID,
-            'Level' => [
-                'operator' => '<',
-                'value' => $StudentCompetency->Level
-            ]
-        ], [
-            'order' => ['Level' => 'DESC']
-        ]);
+        <?php foreach ($graduations as $StudentCompetency) : ?>
+            <?php
+            $previous = Slate\CBL\StudentCompetency::getAllByWhere([
+                'StudentID' => $StudentCompetency->StudentID,
+                'CompetencyID' => $StudentCompetency->CompetencyID,
+                'Level' => [
+                    'operator' => '<',
+                    'value' => $StudentCompetency->Level
+                ]
+            ], [
+                'order' => ['Level' => 'DESC']
+            ]);
 
-        $restorable =
-            $StudentCompetency->EnteredVia == 'graduation'
-            && !$previous[0]->isLevelComplete();
+            $restorable =
+                $StudentCompetency->EnteredVia == 'graduation'
+                && !$previous[0]->isLevelComplete();
 
-        ?>
-        <tr class="<?= $restorable ? 'restorable' : '' ?>">
-            <td><?=$StudentCompetency->ID?></td>
-            <td>
-                <?=$StudentCompetency->Creator->Username?>
-                @ <?=date('Y-m-d H:i:s', $StudentCompetency->Created)?>
-            </td>
-            <td><?=$StudentCompetency->Student->Username?></td>
-            <td><?=$StudentCompetency->Level?></td>
-            <td>
-                <pre><?=var_export($StudentCompetency->getData(), true)?></pre>
-            </td>
-            <td>
-                <table>
-                    <?php foreach ($previous as $PreviousStudentCompetency): ?>
-                    <tr class="<?=$PreviousStudentCompetency->isLevelComplete() ? 'complete' : 'incomplete'?>">
-                        <td><?=$PreviousStudentCompetency->Level?></td>
-                        <td><?=$PreviousStudentCompetency->EnteredVia?></td>
-                        <td>
-                            <?=$PreviousStudentCompetency->Creator->Username?>
-                            @ <?=date('Y-m-d H:i:s', $PreviousStudentCompetency->Created)?>
-                        </td>
-                    </tr>
-                    <?php endforeach ?>
-                </table>
-            </td>
-            <?php if ($restorable): ?>
-                <td class="<?=$restored ? 'restored' : 'unrestored'?>"><?=$restoreTo?></td>
-            <?php endif ?>
-        </tr>
-        <?php flush() ?>
+            ?>
+            <tr class="<?= $restorable ? 'restorable' : '' ?>">
+                <td><?=$StudentCompetency->ID?></td>
+                <td>
+                    <?=$StudentCompetency->Creator->Username?>
+                    @ <?=date('Y-m-d H:i:s', $StudentCompetency->Created)?>
+                </td>
+                <td><?=$StudentCompetency->Student->Username?></td>
+                <td><?=$StudentCompetency->Level?></td>
+                <td>
+                    <pre><?=var_export($StudentCompetency->getData(), true)?></pre>
+                </td>
+                <td>
+                    <table>
+                        <?php foreach ($previous as $PreviousStudentCompetency) : ?>
+                        <tr class="<?=$PreviousStudentCompetency->isLevelComplete() ? 'complete' : 'incomplete'?>">
+                            <td><?=$PreviousStudentCompetency->Level?></td>
+                            <td><?=$PreviousStudentCompetency->EnteredVia?></td>
+                            <td>
+                                <?=$PreviousStudentCompetency->Creator->Username?>
+                                @ <?=date('Y-m-d H:i:s', $PreviousStudentCompetency->Created)?>
+                            </td>
+                        </tr>
+                        <?php endforeach ?>
+                    </table>
+                </td>
+                <?php if ($restorable) : ?>
+                    <td class="<?=$restored ? 'restored' : 'unrestored'?>"><?=$restoreTo?></td>
+                <?php endif ?>
+            </tr>
+            <?php flush() ?>
         <?php endforeach ?>
     </tbody>
 </table>

--- a/site-root/cbl/powertools/review-incomplete-graduations.php
+++ b/site-root/cbl/powertools/review-incomplete-graduations.php
@@ -1,0 +1,106 @@
+<?php
+
+$GLOBALS['Session']->requireAccountLevel('Developer');
+
+
+$minCreatedTime = strtotime('2019-08-20');
+$totalRestored = 0;
+set_time_limit(0);
+ob_end_flush();
+
+
+$graduations = Slate\CBL\StudentCompetency::getAllByQuery(
+    '
+    SELECT StudentCompetency.*
+      FROM cbl_student_competencies StudentCompetency
+     WHERE Created >= FROM_UNIXTIME(%u) AND EnteredVia = "graduation"
+     ORDER BY ID DESC
+    ',
+    [
+        $minCreatedTime
+    ]
+);
+?>
+
+<style>
+    tr.complete {
+        background-color: #DFD;
+    }
+    tr.incomplete {
+        background-color: #FFD;
+    }
+    tr.restorable {
+        background-color: orange;
+    }
+    td.restored {
+        font-weight: bold;
+    }
+    td.unrestored {
+        color: #AAA;
+    }
+</style>
+
+<table border="1">
+    <thead>
+        <tr>
+            <th>StudentCompetencyID</th>
+            <th>Created</th>
+            <th>Student</th>
+            <th>Level</th>
+            <th>Data</th>
+            <th>History</th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <?php foreach ($graduations as $StudentCompetency): ?>
+        <?php
+        $previous = Slate\CBL\StudentCompetency::getAllByWhere([
+            'StudentID' => $StudentCompetency->StudentID,
+            'CompetencyID' => $StudentCompetency->CompetencyID,
+            'Level' => [
+                'operator' => '<',
+                'value' => $StudentCompetency->Level
+            ]
+        ], [
+            'order' => ['Level' => 'DESC']
+        ]);
+
+        $restorable =
+            $StudentCompetency->EnteredVia == 'graduation'
+            && !$previous[0]->isLevelComplete();
+
+        ?>
+        <tr class="<?= $restorable ? 'restorable' : '' ?>">
+            <td><?=$StudentCompetency->ID?></td>
+            <td>
+                <?=$StudentCompetency->Creator->Username?>
+                @ <?=date('Y-m-d H:i:s', $StudentCompetency->Created)?>
+            </td>
+            <td><?=$StudentCompetency->Student->Username?></td>
+            <td><?=$StudentCompetency->Level?></td>
+            <td>
+                <pre><?=var_export($StudentCompetency->getData(), true)?></pre>
+            </td>
+            <td>
+                <table>
+                    <?php foreach ($previous as $PreviousStudentCompetency): ?>
+                    <tr class="<?=$PreviousStudentCompetency->isLevelComplete() ? 'complete' : 'incomplete'?>">
+                        <td><?=$PreviousStudentCompetency->Level?></td>
+                        <td><?=$PreviousStudentCompetency->EnteredVia?></td>
+                        <td>
+                            <?=$PreviousStudentCompetency->Creator->Username?>
+                            @ <?=date('Y-m-d H:i:s', $PreviousStudentCompetency->Created)?>
+                        </td>
+                    </tr>
+                    <?php endforeach ?>
+                </table>
+            </td>
+            <?php if ($restorable): ?>
+                <td class="<?=$restored ? 'restored' : 'unrestored'?>"><?=$restoreTo?></td>
+            <?php endif ?>
+        </tr>
+        <?php flush() ?>
+        <?php endforeach ?>
+    </tbody>
+</table>

--- a/site-root/cbl/powertools/review-incomplete-graduations.php
+++ b/site-root/cbl/powertools/review-incomplete-graduations.php
@@ -46,9 +46,11 @@ $graduations = Slate\CBL\StudentCompetency::getAllByQuery(
             <th>StudentCompetencyID</th>
             <th>Created</th>
             <th>Student</th>
+            <th>Competency</th>
             <th>Level</th>
-            <th>Data</th>
-            <th>History</th>
+            <th>Via</th>
+            <th>Baseline</th>
+            <th>Previous</th>
         </tr>
     </thead>
 
@@ -78,10 +80,10 @@ $graduations = Slate\CBL\StudentCompetency::getAllByQuery(
                     @ <?=date('Y-m-d H:i:s', $StudentCompetency->Created)?>
                 </td>
                 <td><?=$StudentCompetency->Student->Username?></td>
+                <td><?=$StudentCompetency->Competency->Code?></td>
                 <td><?=$StudentCompetency->Level?></td>
-                <td>
-                    <pre><?=var_export($StudentCompetency->getData(), true)?></pre>
-                </td>
+                <td><?=$StudentCompetency->EnteredVia?></td>
+                <td><?=$StudentCompetency->BaselineRating?></td>
                 <td>
                     <table>
                         <?php foreach ($previous as $PreviousStudentCompetency) : ?>

--- a/site-root/cbl/powertools/review-level-jumps.php
+++ b/site-root/cbl/powertools/review-level-jumps.php
@@ -1,0 +1,122 @@
+<?php
+
+$GLOBALS['Session']->requireAccountLevel('Developer');
+
+$jumpedDemoSkills = Slate\CBL\Demonstrations\DemonstrationSkill::getAllByQuery(
+    '
+    SELECT Current.*
+      FROM cbl_demonstration_skills Current
+      JOIN history_cbl_demonstration_skills Historic
+        ON (Historic.ID = Current.ID AND Historic.TargetLevel != Current.TargetLevel)
+     GROUP BY Historic.ID DESC
+    '
+);
+
+$minModifiedTime = strtotime('2019-08-20');
+$totalRestored = 0;
+set_time_limit(0);
+ob_end_flush();
+?>
+
+<?php if (empty($_POST['execute'])): ?>
+    <form method="POST"><input type="submit" name="execute" value="Execute Restorations"></form>
+<?php endif ?>
+
+<style>
+    tr.current td {
+        color: #AAA;
+    }
+    tr.restorable {
+        background-color: #DFD;
+    }
+    td.restored {
+        font-weight: bold;
+    }
+    td.unrestored {
+        color: #AAA;
+    }
+</style>
+
+<table border="1">
+    <thead>
+        <tr>
+            <th>DemonstrationSkillID</th>
+            <th>DemonstrationID</th>
+            <th>Student</th>
+            <th>Skill</th>
+            <th>Last Edit</th>
+            <td>Current Level/Rating</td>
+            <td>Recorded History</td>
+            <td><?= empty($_POST['execute']) ? 'Would Restore' : 'Restored' ?> To</td>
+        </tr>
+    </thead>
+
+    <tbody>
+        <?php foreach ($jumpedDemoSkills as $DemoSkill): ?>
+        <?php
+        $history = DB::allRecords(
+            '
+            SELECT RevisionID,
+                   Created, CreatorID,
+                   Modified, ModifierID,
+                   TargetLevel,
+                   DemonstratedLevel
+             FROM history_cbl_demonstration_skills
+            WHERE ID = %u
+            ORDER BY RevisionID DESC
+            ',
+            $DemoSkill->ID
+        );
+
+        $restorable =
+            count($history) > 1
+            && $DemoSkill->TargetLevel == $history[0]['TargetLevel']
+            && $DemoSkill->TargetLevel != $history[count($history)-1]['TargetLevel']
+            && $DemoSkill->Modified > $minModifiedTime;
+
+        $restoreTo = $restorable ? $history[count($history)-1]['TargetLevel'] : null;
+
+        if (!empty($_POST['execute']) && $restorable) {
+            $DemoSkill->TargetLevel = $restoreTo;
+            $DemoSkill->save();
+            $restored = true;
+            $totalRestored++;
+        } else {
+            $restored = false;
+        }
+
+        ?>
+        <tr class="<?= $restorable ? 'restorable' : '' ?>">
+            <td><?=$DemoSkill->ID?></td>
+            <td><?=$DemoSkill->DemonstrationID?></td>
+            <td><?=$DemoSkill->Demonstration->Student->Username?></td>
+            <td><?=$DemoSkill->Skill->Code?></td>
+            <td>
+                <?=$DemoSkill->Modifier ? $DemoSkill->Modifier->Username : $DemoSkill->Creator->Username?>
+                @ <?=date('Y-m-d H:i:s', $DemoSkill->Modified?:$DemoSkill->Created)?>
+            </td>
+            <td><?=$DemoSkill->TargetLevel?>/<?=$DemoSkill->DemonstratedLevel?></td>
+            <td>
+                <table>
+                    <?php foreach ($history as $demoSkillRevision): ?>
+                    <tr class="<?= $demoSkillRevision['TargetLevel'] == $DemoSkill->TargetLevel ? 'current' : ''?>">
+                        <td><?=$demoSkillRevision['TargetLevel']?>/<?=$demoSkillRevision['DemonstratedLevel']?></td>
+                        <td>
+                            <?=Emergence\People\Person::getByID($demoSkillRevision['ModifierID']?:$demoSkillRevision['CreatorID'])->Username?>
+                            @ <?=$demoSkillRevision['Modified']?:$demoSkillRevision['Created']?>
+                        </td>
+                        <td><?=$demoSkillRevision['RevisionID']?></td>
+                    </tr>
+                    <?php endforeach ?>
+                </table>
+            </td>
+            <?php if ($restorable): ?>
+                <td class="<?=$restored ? 'restored' : 'unrestored'?>"><?=$restoreTo?></td>
+            <?php endif ?>
+        </tr>
+        <?php flush() ?>
+        <?php endforeach ?>
+    </tbody>
+</table>
+
+<p><?=number_format($totalRestored)?> levels restored to initial value</p>

--- a/site-root/cbl/powertools/review-level-jumps.php
+++ b/site-root/cbl/powertools/review-level-jumps.php
@@ -18,7 +18,7 @@ set_time_limit(0);
 ob_end_flush();
 ?>
 
-<?php if (empty($_POST['execute'])): ?>
+<?php if (empty($_POST['execute'])) : ?>
     <form method="POST"><input type="submit" name="execute" value="Execute Restorations"></form>
 <?php endif ?>
 
@@ -52,69 +52,69 @@ ob_end_flush();
     </thead>
 
     <tbody>
-        <?php foreach ($jumpedDemoSkills as $DemoSkill): ?>
-        <?php
-        $history = DB::allRecords(
-            '
-            SELECT RevisionID,
-                   Created, CreatorID,
-                   Modified, ModifierID,
-                   TargetLevel,
-                   DemonstratedLevel
-             FROM history_cbl_demonstration_skills
-            WHERE ID = %u
-            ORDER BY RevisionID DESC
-            ',
-            $DemoSkill->ID
-        );
+        <?php foreach ($jumpedDemoSkills as $DemoSkill) : ?>
+            <?php
+            $history = DB::allRecords(
+                '
+                SELECT RevisionID,
+                    Created, CreatorID,
+                    Modified, ModifierID,
+                    TargetLevel,
+                    DemonstratedLevel
+                FROM history_cbl_demonstration_skills
+                WHERE ID = %u
+                ORDER BY RevisionID DESC
+                ',
+                $DemoSkill->ID
+            );
 
-        $restorable =
-            count($history) > 1
-            && $DemoSkill->TargetLevel == $history[0]['TargetLevel']
-            && $DemoSkill->TargetLevel != $history[count($history)-1]['TargetLevel']
-            && $DemoSkill->Modified > $minModifiedTime;
+            $restorable =
+                count($history) > 1
+                && $DemoSkill->TargetLevel == $history[0]['TargetLevel']
+                && $DemoSkill->TargetLevel != $history[count($history)-1]['TargetLevel']
+                && $DemoSkill->Modified > $minModifiedTime;
 
-        $restoreTo = $restorable ? $history[count($history)-1]['TargetLevel'] : null;
+            $restoreTo = $restorable ? $history[count($history)-1]['TargetLevel'] : null;
 
-        if (!empty($_POST['execute']) && $restorable) {
-            $DemoSkill->TargetLevel = $restoreTo;
-            $DemoSkill->save();
-            $restored = true;
-            $totalRestored++;
-        } else {
-            $restored = false;
-        }
+            if (!empty($_POST['execute']) && $restorable) {
+                $DemoSkill->TargetLevel = $restoreTo;
+                $DemoSkill->save();
+                $restored = true;
+                $totalRestored++;
+            } else {
+                $restored = false;
+            }
 
-        ?>
-        <tr class="<?= $restorable ? 'restorable' : '' ?>">
-            <td><?=$DemoSkill->ID?></td>
-            <td><?=$DemoSkill->DemonstrationID?></td>
-            <td><?=$DemoSkill->Demonstration->Student->Username?></td>
-            <td><?=$DemoSkill->Skill->Code?></td>
-            <td>
-                <?=$DemoSkill->Modifier ? $DemoSkill->Modifier->Username : $DemoSkill->Creator->Username?>
-                @ <?=date('Y-m-d H:i:s', $DemoSkill->Modified?:$DemoSkill->Created)?>
-            </td>
-            <td><?=$DemoSkill->TargetLevel?>/<?=$DemoSkill->DemonstratedLevel?></td>
-            <td>
-                <table>
-                    <?php foreach ($history as $demoSkillRevision): ?>
-                    <tr class="<?= $demoSkillRevision['TargetLevel'] == $DemoSkill->TargetLevel ? 'current' : ''?>">
-                        <td><?=$demoSkillRevision['TargetLevel']?>/<?=$demoSkillRevision['DemonstratedLevel']?></td>
-                        <td>
-                            <?=Emergence\People\Person::getByID($demoSkillRevision['ModifierID']?:$demoSkillRevision['CreatorID'])->Username?>
-                            @ <?=$demoSkillRevision['Modified']?:$demoSkillRevision['Created']?>
-                        </td>
-                        <td><?=$demoSkillRevision['RevisionID']?></td>
-                    </tr>
-                    <?php endforeach ?>
-                </table>
-            </td>
-            <?php if ($restorable): ?>
-                <td class="<?=$restored ? 'restored' : 'unrestored'?>"><?=$restoreTo?></td>
-            <?php endif ?>
-        </tr>
-        <?php flush() ?>
+            ?>
+            <tr class="<?= $restorable ? 'restorable' : '' ?>">
+                <td><?=$DemoSkill->ID?></td>
+                <td><?=$DemoSkill->DemonstrationID?></td>
+                <td><?=$DemoSkill->Demonstration->Student->Username?></td>
+                <td><?=$DemoSkill->Skill->Code?></td>
+                <td>
+                    <?=$DemoSkill->Modifier ? $DemoSkill->Modifier->Username : $DemoSkill->Creator->Username?>
+                    @ <?=date('Y-m-d H:i:s', $DemoSkill->Modified?:$DemoSkill->Created)?>
+                </td>
+                <td><?=$DemoSkill->TargetLevel?>/<?=$DemoSkill->DemonstratedLevel?></td>
+                <td>
+                    <table>
+                        <?php foreach ($history as $demoSkillRevision) : ?>
+                        <tr class="<?= $demoSkillRevision['TargetLevel'] == $DemoSkill->TargetLevel ? 'current' : ''?>">
+                            <td><?=$demoSkillRevision['TargetLevel']?>/<?=$demoSkillRevision['DemonstratedLevel']?></td>
+                            <td>
+                                <?=Emergence\People\Person::getByID($demoSkillRevision['ModifierID']?:$demoSkillRevision['CreatorID'])->Username?>
+                                @ <?=$demoSkillRevision['Modified']?:$demoSkillRevision['Created']?>
+                            </td>
+                            <td><?=$demoSkillRevision['RevisionID']?></td>
+                        </tr>
+                        <?php endforeach ?>
+                    </table>
+                </td>
+                <?php if ($restorable) : ?>
+                    <td class="<?=$restored ? 'restored' : 'unrestored'?>"><?=$restoreTo?></td>
+                <?php endif ?>
+            </tr>
+            <?php flush() ?>
         <?php endforeach ?>
     </tbody>
 </table>


### PR DESCRIPTION
- feat: add student demonstrations dashboard smoke test
- feat: add teacher demonstration test scaffolding
- feat: add student tasks test scaffold
- feat: add teacher task test scaffolding
- feat: add loginAs cypress command
- feat: consolidate before() cypress database commands
- feat: add withExt cypress command
- feat: add withExt helper to teacher demonstrations test
- feat: add teacher tasks dashboard smoke screen test logic
- feat: add student competencies smoke screen test
- feat: complete student tasks cypress test
- feat: add student demonstrations growth metrics test
- feat: add student demonstrations growth metrics test
- feat: add failing student tasks competency rating task
- feat: support running tests remotely
- feat: add powertools for fixing level jumps
- fix: typo
- fix: create database table already exists error
- fix: remove safety check on drop database command
- refactor: force Docker environment for testing / development
- refactor: switch to using Ext ComponentQuery to find element ids
- refactor: replace login with ajax request in beforeEach()
- refactor: code clean up
- refactor: login tests
- refactor: add Ext query selector helpers with withExt command
- refactor: improve variable naming convention
- refactor: code clean up
- refactor: update default fixtures repository
- refactor: teacher demonstrations test with valid data
- refactor: teacher tasks test for real data
- refactor: improve registration / profile editing test description
- refactor: add fixtures repo as submodule
- refactor: use local hologit server as default apiHost
- chore: exclude .github/ from projections
- chore: upgrade studio to 0.6
- style: delint whitespace
- style: tweak StudentCompetency columns