### PR TITLE
Release: slate-cbl v3.0.0-beta.27

### DIFF
--- a/cypress/integration/api/student-competencies.js
+++ b/cypress/integration/api/student-competencies.js
@@ -1,0 +1,113 @@
+describe('/cbl/student-competencies API', () => {
+
+    // load sample database before tests
+    before(() => {
+        cy.resetDatabase();
+    });
+
+    // authenticate as 'teacher' user
+    beforeEach(() => {
+        cy.loginAs('teacher');
+    });
+
+    it('Validation prevents TargetLevel changes', () => {
+
+        cy.request('/cbl/student-competencies?format=json').then(response => {
+            expect(response).property('status').to.eq(200);
+            expect(response).property('body').to.be.an('object');
+            expect(response.body).property('data').to.be.an('array');
+            expect(response.body.data).to.have.length(38);
+            expect(response.body.data[0]).to.include({
+                ID: 38,
+                Class: 'Slate\\CBL\\StudentCompetency',
+                Created: 1570829655,
+                CreatorID: 3,
+                StudentID: 4,
+                CompetencyID: 7,
+                Level: 11,
+                EnteredVia: 'graduation',
+                BaselineRating: 10
+            });
+
+            cy.request('/cbl/student-competencies/1?format=json&include=completion,effectiveDemonstrationsData');
+        }).then(response => {
+            expect(response).property('status').to.eq(200);
+            expect(response).property('body').to.be.an('object');
+
+            expect(response.body).property('data').to.be.an('object');
+            expect(response.body.data).to.include({
+                ID: 1,
+                Class: 'Slate\\CBL\\StudentCompetency',
+                Created: 1546401845,
+                CreatorID: 2,
+                StudentID: 4,
+                CompetencyID: 1,
+                Level: 9,
+                EnteredVia: 'enrollment',
+                BaselineRating: 9
+            });
+
+            expect(response.body.data).property('completion').to.be.an('object');
+            expect(response.body.data.completion).to.include({
+                StudentID: 4,
+                CompetencyID: 1,
+                currentLevel: 9,
+                baselineRating: 9,
+                demonstrationsLogged: 12,
+                demonstrationsMissed: 0,
+                demonstrationsComplete: 12,
+                demonstrationsAverage: 10,
+                demonstrationsRequired: 12,
+                growth: 2
+            });
+
+            expect(response.body.data).property('effectiveDemonstrationsData').to.be.an('object');
+            expect(response.body.data.effectiveDemonstrationsData).to.have.all.keys('1', '2', '3', '4');
+            expect(response.body.data.effectiveDemonstrationsData['1']).to.be.an('array');
+            expect(response.body.data.effectiveDemonstrationsData['1']).to.have.length(3);
+            expect(response.body.data.effectiveDemonstrationsData['1'][0]).to.include({
+                ID: 1,
+                Class: 'Slate\\CBL\\Demonstrations\\DemonstrationSkill',
+                Created: 1546401845,
+                CreatorID: 3,
+                Modified: null,
+                ModifierID: null,
+                DemonstrationID: 1,
+                SkillID: 1,
+                TargetLevel: 9,
+                DemonstratedLevel: 9,
+                Override: false,
+                DemonstrationDate: 1570819947
+            });
+
+            cy.request('POST', '/cbl/student-tasks/save?format=json&include=Demonstration.DemonstrationSkills', {
+                data: [{
+                    ID: 1,
+                    DemonstrationSkills: [{
+                        ID: 1,
+                        SkillID: 1,
+                        TargetLevel: 10,
+                        DemonstratedLevel: 11
+                    }]
+                }]
+            });
+        }).then(response => {
+            expect(response).property('status').to.eq(200);
+            expect(response).property('body').to.be.an('object');
+            expect(response.body).property('data').to.be.an('array');
+            expect(response.body.data).to.have.length(1);
+            expect(response.body.data[0]).property('Demonstration').to.be.an('object');
+            expect(response.body.data[0].Demonstration).property('DemonstrationSkills').to.be.an('array');
+            expect(response.body.data[0].Demonstration.DemonstrationSkills).to.have.length(1);
+            expect(response.body.data[0].Demonstration.DemonstrationSkills[0]).to.be.an('object');
+            expect(response.body.data[0].Demonstration.DemonstrationSkills[0]).to.include({
+                ID: 1,
+                SkillID: 1,
+                DemonstratedLevel: 11,
+                TargetLevel: 9,
+                Override: false,
+                Removable: false
+            });
+        });
+    });
+});

--- a/php-classes/Slate/CBL/Demonstrations/DemonstrationSkill.php
+++ b/php-classes/Slate/CBL/Demonstrations/DemonstrationSkill.php
@@ -83,6 +83,11 @@ class DemonstrationSkill extends \VersionedRecord
             $this->_validator->addError('DemonstratedLevel', 'DemonstratedLevel must not be null for non-override');
         }
 
+        // target level can only be set on new records
+        if (!$this->isPhantom && $this->isFieldDirty('TargetLevel')) {
+            $this->_validator->addError('TargetLevel', 'TargetLevel cannot be changed on existing records');
+        }
+
         // save results
         return $this->finishValidation();
     }

--- a/php-classes/Slate/CBL/Tasks/StudentTasksRequestHandler.php
+++ b/php-classes/Slate/CBL/Tasks/StudentTasksRequestHandler.php
@@ -2,6 +2,8 @@
 
 namespace Slate\CBL\Tasks;
 
+use Exception;
+
 use DB;
 use JSON;
 use ActiveRecord;

--- a/sencha-workspace/packages/slate-cbl/src/field/ratings/SkillsField.js
+++ b/sencha-workspace/packages/slate-cbl/src/field/ratings/SkillsField.js
@@ -373,7 +373,9 @@ Ext.define('Slate.cbl.field.ratings.SkillsField', {
                 // fetch level or queue for loading
                 studentCompetency = studentCompetenciesStore.getByCompetencyId(competencyId);
 
-                if (studentCompetency) {
+                if (demonstrationSkill.TargetLevel) {
+                    level = demonstrationSkill.TargetLevel;
+                } else if (studentCompetency) {
                     level = studentCompetency.get('Level');
                 } else {
                     level = null;
@@ -518,16 +520,16 @@ Ext.define('Slate.cbl.field.ratings.SkillsField', {
                 var valueSkillsMap = me.valueSkillsMap,
                     competencyLevels = {},
                     studentCompetenciesLength = studentCompetenciesStore.getCount(),
-                    studentCompetencyIndex = 0, studentCompetency, competencyId, level,
+                    studentCompetencyIndex = 0, studentCompetency, competencyId, defaultLevel,
                     competencyContainer, ratingFields, ratingFieldsLength, ratingFieldIndex, ratingField, skillData;
 
                 for (; studentCompetencyIndex < studentCompetenciesLength; studentCompetencyIndex++) {
                     studentCompetency = studentCompetenciesStore.getAt(studentCompetencyIndex);
                     competencyId = studentCompetency.get('CompetencyID');
-                    level = studentCompetency.get('Level');
+                    defaultLevel = studentCompetency.get('Level');
 
-                    if ((competencyLevels[competencyId]||0) < level) {
-                        competencyLevels[competencyId] = level;
+                    if ((competencyLevels[competencyId]||0) < defaultLevel) {
+                        competencyLevels[competencyId] = defaultLevel;
                     }
                 }
 
@@ -538,7 +540,7 @@ Ext.define('Slate.cbl.field.ratings.SkillsField', {
                         continue;
                     }
 
-                    level = competencyLevels[competencyId];
+                    defaultLevel = competencyLevels[competencyId];
                     competencyContainer = competencyContainers[competencyId];
 
                     if (!competencyContainer) {
@@ -549,14 +551,19 @@ Ext.define('Slate.cbl.field.ratings.SkillsField', {
                     ratingFieldsLength = ratingFields.getCount();
                     ratingFieldIndex = 0;
 
+                    // use default / current target level for phantom skills
                     for (; ratingFieldIndex < ratingFieldsLength; ratingFieldIndex++) {
                         ratingField = ratingFields.getAt(ratingFieldIndex);
-                        ratingField.setLevel(level);
-
                         skillData = valueSkillsMap[ratingField.getSkill().getId()];
 
                         if (skillData) {
-                            skillData.TargetLevel = level;
+                            if (!skillData.TargetLevel) {
+                                skillData.TargetLevel = defaultLevel;
+                            }
+
+                            ratingField.setLevel(skillData.TargetLevel);
+                        } else {
+                            ratingField.setLevel(defaultLevel);
                         }
                     }
                 }


### PR DESCRIPTION
- fix: use existing demonstration skill's target level when available
- fix: add missing use for Exception class
- fix: reject any changes to TargetLevel for existing DemonstrationSkills
- test: add failing test for demonstration API
- test: ensure TargetLevel can't be changed through StudentTask API