### PR TITLE
Release: slate-cbl v3.0.0-beta.31

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
     "env": {
-        "browser": true
+        "browser": true,
+        "es6": true
     },
     "globals": {
         "Ext": true

--- a/data-exporters/slate-cbl/student-competencies.php
+++ b/data-exporters/slate-cbl/student-competencies.php
@@ -32,7 +32,7 @@ return [
 
         if (!empty($input['content_area'])) {
             if (!$ContentArea = Slate\CBL\ContentArea::getByCode($input['content_area'])) {
-                throw new Exception('content area not found');
+                throw new OutOfBoundsException('content area not found');
             }
 
             $query['content_area'] = $ContentArea->Code;
@@ -91,7 +91,7 @@ return [
         if ($query['level']) {
             $conditions['Level'] = $query['level'];
         }
-        
+
         if ($query['only_highest']) {
             $conditions[] = sprintf(
                 'NOT EXISTS (
@@ -117,7 +117,7 @@ return [
                       FROM `%s` StudentCompetency
                      WHERE StudentID = %u
                        AND (%s)
-                     ORDER BY %s 
+                     ORDER BY %s
                 ',
                 [
                     Slate\CBL\StudentCompetency::$tableName,

--- a/data-exporters/slate-cbl/student-portfolios.php
+++ b/data-exporters/slate-cbl/student-portfolios.php
@@ -32,7 +32,7 @@ return [
 
         if (!empty($input['content_area'])) {
             if (!$ContentArea = Slate\CBL\ContentArea::getByCode($input['content_area'])) {
-                throw new Exception('content area not found');
+                throw new OutOfBoundsException('content area not found');
             }
 
             $query['content_area'] = $ContentArea->Code;
@@ -87,7 +87,7 @@ return [
         if ($query['level']) {
             $conditions['Level'] = $query['level'];
         }
-        
+
 #        if ($query['only_highest']) {
 #            $conditions[] = sprintf(
 #                'NOT EXISTS (
@@ -116,7 +116,7 @@ return [
                         ON Competency.ID = StudentCompetency.CompetencyID
                      WHERE StudentID = %u
                        AND (%s)
-                     ORDER BY %s 
+                     ORDER BY %s
                 ',
                 [
                     Slate\CBL\StudentCompetency::$tableName,
@@ -209,7 +209,7 @@ return [
 
                     $finishedPortfolio = null;
                 }
-                
+
                 if (!$record) {
                     break;
                 }

--- a/html-templates/exports/exports.tpl
+++ b/html-templates/exports/exports.tpl
@@ -1,6 +1,8 @@
 {extends designs/site.tpl}
 
 {block content}
+    {load_templates "subtemplates/slate-forms.tpl"}
+
     {foreach key=scriptPath item=script from=$scripts implode="<hr>"}
         <h2>{$script.title|escape}</h2>
 
@@ -19,6 +21,35 @@
                         default=$value
                         placeholder='123,345'
                         hint='List of student IDs, group:grouphandle, or section:sectioncode, or all'
+                    }
+                {elseif $key == 'term'}
+                    {termField
+                        inputName=$key
+                        label=$label
+                        default=$value
+                        blankOption='any'
+                        currentOption='current'
+                    }
+                {elseif $key == 'course'}
+                    {courseField
+                        inputName=$key
+                        label=$label
+                        default=$value
+                        blankOption='any'
+                    }
+                {elseif $key == 'location'}
+                    {locationField
+                        inputName=$key
+                        label=$label
+                        default=$value
+                        blankOption='any'
+                    }
+                {elseif $key == 'schedule'}
+                    {scheduleField
+                        inputName=$key
+                        label=$label
+                        default=$value
+                        blankOption='any'
                     }
                 {elseif $key == 'content_area'}
                     {selectField

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,12 +54,12 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
+      "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
@@ -344,9 +344,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.8.2.tgz",
-      "integrity": "sha512-aTs0u3+dfEuLe0Ct0FVO5jD1ULqxbuqWUZwzBm0rxdLgLxIAOI/A9f/WkgY5Cfy1TEXe8pKC6Wal0ZpnkdGRSw==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.8.3.tgz",
+      "integrity": "sha512-I9L/d+ilTPPA4vq3NC1OPKmw7jJIpMKNdyfR8t1EXYzYCjyqbc59migOm1YSse/VRbISLJ+QGb5k4Y3bz2lkYw==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",
@@ -532,9 +532,9 @@
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
       "dev": true
     },
     "fast-json-stable-stringify": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Development tooling for slate-cbl",
   "devDependencies": {
-    "cypress": "^3.8.2",
+    "cypress": "^3.8.3",
     "cypress-plugin-tab": "^1.0.1"
   },
   "scripts": {

--- a/php-classes/Slate/CBL/Tasks/Task.php
+++ b/php-classes/Slate/CBL/Tasks/Task.php
@@ -201,9 +201,12 @@ class Task extends \VersionedRecord
 
     protected static function validateParentTask($validator, Task $Task, $options)
     {
-        if (!$validator->hasErrors('ParentTask') && $Task->ParentTaskID) {
-            if ($Task->ParentTaskID === $Task->ID) {
-                $validator->addError('ParentTask', 'ParentTaskID and TaskID must be different.');
+        if (!$validator->hasErrors('ParentTaskID') && $Task->ParentTaskID) {
+            if ($Task->ParentTaskID == $Task->ID) {
+                $validator->addError('ParentTaskID', 'A task cannot be its own parent');
+
+                // clear immediately to prevent validation loop
+                $Task->ParentTaskID = null;
             }
         }
     }

--- a/php-classes/Slate/CBL/Tasks/Task.php
+++ b/php-classes/Slate/CBL/Tasks/Task.php
@@ -72,7 +72,10 @@ class Task extends \VersionedRecord
 
     public static $validators = [
         'Section' => 'require-relationship',
-        'Title'
+        'Title',
+        'ParentTaskID' => [
+            'validator' => [__CLASS__, 'validateParentTask']
+        ]
     ];
 
     public static $relationships = [
@@ -194,5 +197,14 @@ class Task extends \VersionedRecord
         ));
 
         return DB::affectedRows() > 0;
+    }
+
+    protected static function validateParentTask($validator, Task $Task, $options)
+    {
+        if (!$validator->hasErrors('ParentTask') && $Task->ParentTaskID) {
+            if ($Task->ParentTaskID === $Task->ID) {
+                $validator->addError('ParentTask', 'ParentTaskID and TaskID must be different.');
+            }
+        }
     }
 }

--- a/php-migrations/Slate/CBL/Tasks/20200121_invalid-parent-tasks.php
+++ b/php-migrations/Slate/CBL/Tasks/20200121_invalid-parent-tasks.php
@@ -1,0 +1,36 @@
+<?php
+
+use Slate\CBL\Tasks\Task;
+
+// skip if Task table does not exist or has no ParentTaskID column
+if (!static::tableExists(Task::$tableName)) {
+    printf("Skipping migration because table `%s` does not yet exist\n", Task::$tableName);
+    return static::STATUS_SKIPPED;
+}
+
+if (!static::columnExists(Task::$tableName, 'ParentTaskID')) {
+    printf("Skipping migration because column `%s`.`ParentTaskID` does not exist\n", Task::$tableName);
+    return static::STATUS_SKIPPED;
+}
+
+$invalidTasks = Task::getAllByWhere([
+    'ParentTaskID = ID'
+], ['indexField' => 'ID']);
+
+if (!empty($invalidTasks)) {
+    printf("Updating %u invalid task records", count($invalidTasks));
+    DB::nonQuery(
+        '
+            UPDATE `%s`
+               SET ParentTaskID = NULL
+             WHERE ParentTaskID = ID
+        ',
+        [
+            Task::$tableName
+        ]
+    );
+    return static::STATUS_EXECUTED;
+} else {
+    printf("Skipping migration because there are no invalid parent tasks.");
+    return static::STATUS_SKIPPED;
+}

--- a/sencha-workspace/SlateTasksTeacher/app/controller/Tasks.js
+++ b/sencha-workspace/SlateTasksTeacher/app/controller/Tasks.js
@@ -365,8 +365,11 @@ Ext.define('SlateTasksTeacher.controller.Tasks', {
 
             formPanel.setTask(task);
             formWindow.show();
-            formPanel.getParentTaskField().getStore().filter(function(parentTask) {
-                return parentTask.getId() !== task.getId();
+            formPanel.getParentTaskField().getStore().filter({
+                id: 'exclude-self',
+                property: 'ID',
+                operator: '!=',
+                value: task.getId()
             });
         } else if (typeof task == 'number') {
             formPanel.setTask(null);
@@ -377,8 +380,11 @@ Ext.define('SlateTasksTeacher.controller.Tasks', {
                 success: function(loadedTask) {
                     formPanel.setTask(loadedTask);
                     formWindow.setLoading(false);
-                    formPanel.getParentTaskField().getStore().filter(function(parentTask) {
-                        return parentTask.getId() !== loadedTask.getId();
+                    formPanel.getParentTaskField().getStore().filter({
+                        id: 'exclude-self',
+                        property: 'ID',
+                        operator: '!=',
+                        value: loadedTask.getId()
                     });
                 },
                 failure: function(loadedTask, operation) {

--- a/sencha-workspace/SlateTasksTeacher/app/controller/Tasks.js
+++ b/sencha-workspace/SlateTasksTeacher/app/controller/Tasks.js
@@ -365,6 +365,9 @@ Ext.define('SlateTasksTeacher.controller.Tasks', {
 
             formPanel.setTask(task);
             formWindow.show();
+            formPanel.getParentTaskField().getStore().filter(function(parentTask) {
+                return parentTask.getId() !== task.getId();
+            });
         } else if (typeof task == 'number') {
             formPanel.setTask(null);
             formWindow.show();
@@ -374,6 +377,9 @@ Ext.define('SlateTasksTeacher.controller.Tasks', {
                 success: function(loadedTask) {
                     formPanel.setTask(loadedTask);
                     formWindow.setLoading(false);
+                    formPanel.getParentTaskField().getStore().filter(function(parentTask) {
+                        return parentTask.getId() !== loadedTask.getId();
+                    });
                 },
                 failure: function(loadedTask, operation) {
                     formWindow.hide();

--- a/sencha-workspace/SlateTasksTeacher/app/controller/Tasks.js
+++ b/sencha-workspace/SlateTasksTeacher/app/controller/Tasks.js
@@ -363,14 +363,14 @@ Ext.define('SlateTasksTeacher.controller.Tasks', {
                 Section: section.getData()
             }, task || null));
 
-            formPanel.setTask(task);
-            formWindow.show();
             formPanel.getParentTaskField().getStore().filter({
                 id: 'exclude-self',
                 property: 'ID',
                 operator: '!=',
                 value: task.getId()
             });
+            formPanel.setTask(task);
+            formWindow.show();
         } else if (typeof task == 'number') {
             formPanel.setTask(null);
             formWindow.show();
@@ -378,14 +378,14 @@ Ext.define('SlateTasksTeacher.controller.Tasks', {
 
             TaskModel.load(task, {
                 success: function(loadedTask) {
-                    formPanel.setTask(loadedTask);
-                    formWindow.setLoading(false);
                     formPanel.getParentTaskField().getStore().filter({
                         id: 'exclude-self',
                         property: 'ID',
                         operator: '!=',
                         value: loadedTask.getId()
                     });
+                    formPanel.setTask(loadedTask);
+                    formWindow.setLoading(false);
                 },
                 failure: function(loadedTask, operation) {
                     formWindow.hide();


### PR DESCRIPTION
- feat: add term/course/location/schedule exporter fields
- fix: prevent parent task paradox (#503)
- chore: bump submodule for database fixtures
- chore: bump cypress version to 3.8.3
- chore: enable es6 globals for eslint
- style: use OutOfBoundsException