### PR TITLE
fix: StudentTask model default TaskStatus

### DIFF
--- a/sencha-workspace/packages/slate-cbl/src/model/tasks/StudentTask.js
+++ b/sencha-workspace/packages/slate-cbl/src/model/tasks/StudentTask.js
@@ -116,7 +116,8 @@ Ext.define('Slate.cbl.model.tasks.StudentTask', function() {
             {
                 name: 'TaskStatus',
                 type: 'string',
-                allowNull: true
+                allowNull: true,
+                defaultValue: 'assigned'
             },
             {
                 name: 'DemonstrationID',


### PR DESCRIPTION
- [x] Update StudentTask model default value for `TaskStatus` column

This is to resolve an issue where "Assigning a Student Task" in the SlateTasksTeacher application fails.