### PR TITLE
Release: slate-cbl v3.0.0-beta.36

### DIFF
--- a/.holo/sources/slate.toml
+++ b/.holo/sources/slate.toml
@@ -1,3 +1,6 @@
 [holosource]
 url = "https://github.com/SlateFoundation/slate"
 ref = "refs/tags/v2.9.4"
+
+[holosource.project]
+holobranch = "emergence-skeleton"

--- a/.holo/sources/slate.toml
+++ b/.holo/sources/slate.toml
@@ -1,3 +1,3 @@
 [holosource]
 url = "https://github.com/SlateFoundation/slate"
-ref = "refs/heads/emergence/skeleton/v2"
+ref = "refs/tags/v2.9.4"


### PR DESCRIPTION
- chore: bump slate to v2.9.4