### PR TITLE
slate-cbl v3.0.0-beta.40

### DIFF
--- a/.holo/sources/slate.toml
+++ b/.holo/sources/slate.toml
@@ -1,6 +1,6 @@
 [holosource]
 url = "https://github.com/SlateFoundation/slate"
-ref = "refs/tags/v2.9.4"
+ref = "refs/tags/v2.9.6"
 
 [holosource.project]
 holobranch = "emergence-skeleton"


### PR DESCRIPTION
- [x] chore: bump slate v2.9.6