### PR TITLE
Release: slate-cbl v3.0.0-beta.41

### DIFF
--- a/.holo/sources/slate.toml
+++ b/.holo/sources/slate.toml
@@ -1,6 +1,6 @@
 [holosource]
 url = "https://github.com/SlateFoundation/slate"
-ref = "refs/tags/v2.9.6"
+ref = "refs/tags/v2.9.10"
 
 [holosource.project]
 holobranch = "emergence-skeleton"


### PR DESCRIPTION
- chore: bump slate to v2.9.10