### PR TITLE
Release: slate-cbl v3.0.0-rc.2

### DIFF
--- a/.holo/sources/slate.toml
+++ b/.holo/sources/slate.toml
@@ -1,6 +1,6 @@
 [holosource]
 url = "https://github.com/SlateFoundation/slate"
-ref = "refs/tags/v2.10.0"
+ref = "refs/tags/v2.10.1"
 
 [holosource.project]
 holobranch = "emergence-skeleton"


### PR DESCRIPTION
- chore: bump slate version to v2.10.1