### PR TITLE
feat: extended dynamic section titles [SCHOOL-15]

### DIFF
--- a/.holo/sources/slate.toml
+++ b/.holo/sources/slate.toml
@@ -1,3 +1,3 @@
 [holosource]
 url = "https://github.com/SlateFoundation/slate"
-ref = "refs/heads/develop"
+ref = "refs/tags/v2.11.0"

--- a/.holo/sources/slate.toml
+++ b/.holo/sources/slate.toml
@@ -1,3 +1,3 @@
 [holosource]
 url = "https://github.com/SlateFoundation/slate"
-ref = "refs/tags/v2.10.2"
+ref = "refs/heads/develop"

--- a/sencha-workspace/packages/slate-cbl/src/field/SectionSelector.js
+++ b/sencha-workspace/packages/slate-cbl/src/field/SectionSelector.js
@@ -19,6 +19,7 @@ Ext.define('Slate.cbl.field.SectionSelector', {
     componentCls: 'slate-cbl-sectionselector',
 
     listConfig: {
+        cls: 'slate-cbl-sectionselector-list',
         maxWidth: 512,
         minWidth: 256
     },
@@ -37,7 +38,7 @@ Ext.define('Slate.cbl.field.SectionSelector', {
                 '</div>',
             '</tpl>',
 
-            '<div class="x-boundlist-item">{recordTitle}</div>',
+            '<div class="x-boundlist-item"><small class="code">{Code}</small> {recordTitle}</div>',
         '</tpl>'
     ]
 });

--- a/sencha-workspace/packages/slate-cbl/src/field/SectionSelector.js
+++ b/sencha-workspace/packages/slate-cbl/src/field/SectionSelector.js
@@ -7,7 +7,7 @@ Ext.define('Slate.cbl.field.SectionSelector', {
         fieldLabel: 'Course Section',
         labelWidth: 120,
 
-        displayField: 'Title',
+        displayField: 'recordTitle',
         valueField: 'Code',
         forceSelection: true,
         editable: false,
@@ -37,7 +37,7 @@ Ext.define('Slate.cbl.field.SectionSelector', {
                 '</div>',
             '</tpl>',
 
-            '<div class="x-boundlist-item">{Title}</div>',
+            '<div class="x-boundlist-item">{recordTitle}</div>',
         '</tpl>'
     ]
 });

--- a/sencha-workspace/packages/slate-cbl/src/field/SectionSelector.scss
+++ b/sencha-workspace/packages/slate-cbl/src/field/SectionSelector.scss
@@ -1,0 +1,7 @@
+.slate-cbl-sectionselector-list {
+    .code {
+        float: right;
+        font-family: $mono-font;
+        margin-left: 1em;
+    }
+}

--- a/sencha-workspace/packages/slate-cbl/src/field/StudentsListSelector.js
+++ b/sencha-workspace/packages/slate-cbl/src/field/StudentsListSelector.js
@@ -68,7 +68,12 @@ Ext.define('Slate.cbl.field.StudentsListSelector', {
                 '</div>',
             '</tpl>',
 
-            '<div class="x-boundlist-item">{label}</div>',
+            '<div class="x-boundlist-item">',
+                '<tpl if="code">',
+                    '<small class="code">{code}</small> ',
+                '</tpl>',
+                '{label}',
+            '</div>',
         '</tpl>'
     ],
 

--- a/sencha-workspace/packages/slate-cbl/src/field/StudentsListSelector.scss
+++ b/sencha-workspace/packages/slate-cbl/src/field/StudentsListSelector.scss
@@ -3,4 +3,10 @@
         font-size: 0.75em;
         float: right;
     }
+
+    .code {
+        float: right;
+        font-family: $mono-font;
+        margin-left: 1em;
+    }
 }


### PR DESCRIPTION
## Why

School users need more information in lists of sections to separate them

## What

- Use dynamic titles in section selector
- Add codes to sections selector and students list selector

## TODO

- [x] Requires SlateFoundation/slate#250, bump slate version within this PR before merging
- [x] show codes in section selector

## Screenshots

![image](https://user-images.githubusercontent.com/458494/103164468-8339a300-47d9-11eb-9242-d8e43d9131b6.png)

![image](https://user-images.githubusercontent.com/458494/103164471-8c2a7480-47d9-11eb-8098-1e5acb3f8701.png)
