### PR TITLE
fix(student tasks): use ->getTitle() for dynamic section titles

### DIFF
--- a/php-classes/Slate/CBL/Tasks/StudentTask.php
+++ b/php-classes/Slate/CBL/Tasks/StudentTask.php
@@ -174,8 +174,8 @@ class StudentTask extends \VersionedRecord
         if (!$this->Demonstration) {
             $this->Demonstration = ExperienceDemonstration::create([
                 'StudentID' => $this->StudentID,
-                'PerformanceType' => $this->Task->Title,
-                'Context' => $this->Task->Section->Title,
+                'PerformanceType' => $this->Task->getTitle(),
+                'Context' => $this->Task->Section->getTitle(),
                 'ExperienceType' => $this->Task->ExperienceType
             ]);
         }

--- a/php-migrations/Slate/CBL/Tasks/20161007000000_student-task-ratings.php
+++ b/php-migrations/Slate/CBL/Tasks/20161007000000_student-task-ratings.php
@@ -65,8 +65,8 @@ foreach ($taskRatings as $taskRating) {
             'StudentID' => $StudentTask->StudentID,
             'Demonstrated' => $StudentTask->Submitted ?: null,
             'ExperienceType' => $StudentTask->ExperienceType,
-            'PerformanceType' => $StudentTask->Task->Title,
-            'Context' => $StudentTask->Section->Title
+            'PerformanceType' => $StudentTask->Task->getTitle(),
+            'Context' => $StudentTask->Section->getTitle()
         ]);
         $Demonstration->save(false);
 


### PR DESCRIPTION
This should fix this issue reported by Tom: https://jarvus.slack.com/archives/C5KDU8W0Y/p1633377193023100

It will prevent the system from trying to create invalid StudentTask records when sections have no explicit title filled in, using the dynamic title instead that defaults to associated course titles