### PR TITLE
fix: remove quotes from attachments list

### DIFF
--- a/data-exporters/slate-cbl/student-tasks.php
+++ b/data-exporters/slate-cbl/student-tasks.php
@@ -274,13 +274,13 @@ return [
             foreach ($StudentTask->Task->Attachments as $Attachment) {
                 $attachments[] = $Attachment->URL;
             }
-            $teacherAttachments = !empty($attachments) ? '"'.implode('", "', $attachments).'"' : null;
+            $teacherAttachments = !empty($attachments) ? implode(',', $attachments) : null;
 
             $attachments = [];
             foreach ($StudentTask->Attachments as $Attachment) {
                 $attachments[] = $Attachment->URL;
             }
-            $studentAttachments = !empty($attachments) ? '"'.implode('", "', $attachments).'"' : null;
+            $studentAttachments = !empty($attachments) ? implode(',', $attachments) : null;
 
             yield [
                 'StudentTaskID' => $StudentTask->ID,


### PR DESCRIPTION
This removes the quotes from the comma separated lists of attachments in the student and teacher attachment fields in the student tasks export.