### PR TITLE
Prevent parent tasks from being made subtasks [SCHOOL-146]

### DIFF
--- a/php-classes/Slate/CBL/Tasks/Task.php
+++ b/php-classes/Slate/CBL/Tasks/Task.php
@@ -215,6 +215,13 @@ class Task extends \VersionedRecord
                 // clear immediately to prevent validation loop
                 $Task->ParentTaskID = null;
             }
+
+            if (!empty($Task->SubTasks)) {
+                $validator->addError('ParentTaskID', 'A task with subtasks is a parent task and cannot be a subtask of another task');
+
+                // clear immediately to prevent validation loop
+                $Task->ParentTaskID = null;
+            }
         }
     }
 

--- a/sencha-workspace/SlateTasksTeacher/app/controller/Tasks.js
+++ b/sencha-workspace/SlateTasksTeacher/app/controller/Tasks.js
@@ -319,7 +319,7 @@ Ext.define('SlateTasksTeacher.controller.Tasks', {
                 tasksStore.mergeData([savedTask]);
 
                 if (parentTask) {
-                    parentTask.get('ChildTasks').push(savedTask);
+                    parentTask.get('SubTasks').push(savedTask);
                 }
 
                 tasksStore.endUpdate();
@@ -380,7 +380,7 @@ Ext.define('SlateTasksTeacher.controller.Tasks', {
                 tasksStore.mergeData([savedTask]);
 
                 if (parentTask) {
-                    parentTask.get('ChildTasks').push(savedTask);
+                    parentTask.get('SubTasks').push(savedTask);
                 }
 
                 tasksStore.endUpdate();
@@ -443,7 +443,7 @@ Ext.define('SlateTasksTeacher.controller.Tasks', {
                 tasksStore.mergeData([savedTask]);
 
                 if (parentTask) {
-                    parentTask.get('ChildTasks').push(savedTask);
+                    parentTask.get('SubTasks').push(savedTask);
                 }
 
                 tasksStore.endUpdate();

--- a/sencha-workspace/SlateTasksTeacher/app/view/StudentsGrid.js
+++ b/sencha-workspace/SlateTasksTeacher/app/view/StudentsGrid.js
@@ -125,7 +125,7 @@ Ext.define('SlateTasksTeacher.view.StudentsGrid', function() {
 
         // Aggregrid template methods
         isRowExpandable: function(row) {
-            return row.get('ChildTasks').length > 0;
+            return row.get('SubTasks').length > 0;
         },
 
         buildColumnTplData: function() {

--- a/sencha-workspace/packages/slate-cbl/src/model/tasks/Task.js
+++ b/sencha-workspace/packages/slate-cbl/src/model/tasks/Task.js
@@ -190,7 +190,7 @@ Ext.define('Slate.cbl.model.tasks.Task', {
 
         // virtual fields
         {
-            name: 'ChildTasks',
+            name: 'SubTasks',
             defaultValue: [],
             persist: true
         }
@@ -198,7 +198,7 @@ Ext.define('Slate.cbl.model.tasks.Task', {
 
     proxy: {
         type: 'slate-cbl-tasks',
-        include: ['Assignees', 'Attachments.File', 'Skills', 'ClonedTask']
+        include: ['Assignees', 'Attachments.File', 'Skills', 'ClonedTask', 'SubTasks']
     },
 
     // TODO: review if still needed

--- a/sencha-workspace/packages/slate-cbl/src/store/tasks/Tasks.js
+++ b/sencha-workspace/packages/slate-cbl/src/store/tasks/Tasks.js
@@ -24,9 +24,9 @@ Ext.define('Slate.cbl.store.tasks.Tasks', {
 
     loadRecords: function() {
         var me = this,
-            childTasksByParent = {},
+            subTasksByParent = {},
             count, index, task, parentTaskId,
-            childTasks, childTasksLength, childTaskIndex, taskData;
+            subTasks, subTasksLength, subTaskIndex, taskData;
 
         me.callParent(arguments);
 
@@ -43,24 +43,24 @@ Ext.define('Slate.cbl.store.tasks.Tasks', {
                 continue;
             }
 
-            if (parentTaskId in childTasksByParent) {
-                childTasksByParent[parentTaskId].push(task);
+            if (parentTaskId in subTasksByParent) {
+                subTasksByParent[parentTaskId].push(task);
             } else {
-                childTasksByParent[parentTaskId] = [task];
+                subTasksByParent[parentTaskId] = [task];
             }
         }
 
         for (index = 0; index < count; index++) {
             task = me.getAt(index);
             taskData = task.getData();
-            childTasks = childTasksByParent[task.getId()] || [];
-            childTasksLength = childTasks.length;
-            childTaskIndex = 0;
+            subTasks = subTasksByParent[task.getId()] || [];
+            subTasksLength = subTasks.length;
+            subTaskIndex = 0;
 
-            task.set('SubTasks', childTasks, { dirty: false });
+            task.set('SubTasks', subTasks, { dirty: false });
 
-            for (; childTaskIndex < childTasksLength; childTaskIndex++) {
-                childTasks[childTaskIndex].set('ParentTask', taskData, { dirty: false });
+            for (; subTaskIndex < subTasksLength; subTaskIndex++) {
+                subTasks[subTaskIndex].set('ParentTask', taskData, { dirty: false });
             }
         }
         me.endUpdate();

--- a/sencha-workspace/packages/slate-cbl/src/store/tasks/Tasks.js
+++ b/sencha-workspace/packages/slate-cbl/src/store/tasks/Tasks.js
@@ -32,7 +32,7 @@ Ext.define('Slate.cbl.store.tasks.Tasks', {
 
         me.beginUpdate();
 
-        // decorate Task records with ChildTasks arrays and ParentTask references
+        // decorate Task records with SubTasks arrays and ParentTask references
         count = me.getCount();
 
         for (index = 0; index < count; index++) {
@@ -57,7 +57,7 @@ Ext.define('Slate.cbl.store.tasks.Tasks', {
             childTasksLength = childTasks.length;
             childTaskIndex = 0;
 
-            task.set('ChildTasks', childTasks, { dirty: false });
+            task.set('SubTasks', childTasks, { dirty: false });
 
             for (; childTaskIndex < childTasksLength; childTaskIndex++) {
                 childTasks[childTaskIndex].set('ParentTask', taskData, { dirty: false });

--- a/sencha-workspace/packages/slate-cbl/src/view/tasks/TaskForm.js
+++ b/sencha-workspace/packages/slate-cbl/src/view/tasks/TaskForm.js
@@ -254,7 +254,7 @@ Ext.define('Slate.cbl.view.tasks.TaskForm', function() {
                 );
 
                 // Hide the parentTask field if this task is a parent of other tasks
-                me.getParentTaskField().setHidden(task.get('ChildTasks').length > 0);
+                me.getParentTaskField().setHidden(task.get('SubTasks').length > 0);
 
                 me.getClonedTaskField().setHidden(!task.phantom);
                 me.getClonedTaskDisplayField().setHidden(task.phantom);

--- a/sencha-workspace/packages/slate-cbl/src/view/tasks/TaskForm.js
+++ b/sencha-workspace/packages/slate-cbl/src/view/tasks/TaskForm.js
@@ -253,6 +253,9 @@ Ext.define('Slate.cbl.view.tasks.TaskForm', function() {
                         : Ext.String.format(me.getInitialConfig('editTitle'), task.getId(), task.get('Title'))
                 );
 
+                // Hide the parentTask field if this task is a parent of other tasks
+                me.getParentTaskField().setHidden(task.get('ChildTasks').length > 0);
+
                 me.getClonedTaskField().setHidden(!task.phantom);
                 me.getClonedTaskDisplayField().setHidden(task.phantom);
                 me.show();


### PR DESCRIPTION
The tasks UI currently is only able to handle one level of parent->child task nesting, but the task edit form doesn’t stop you from assigning parent tasks across multiple levels. The result right now of doing this is that child tasks past the 2nd level disappear from the UI and aren’t reachable

This PR adds frontend and backend restrictions on selecting a parent task for tasks that already have children.  On the backend, attempting to save a parent task that has a parentTaskID will cause an error.  On the frontend, the parent task field will be hidden when editing parent tasks