### PR TITLE
fix: Performance Level Minus Baseline Growth Calculation [SCHOOL-101]

### DIFF
--- a/php-classes/Slate/CBL/Calculators/Growth/PerformanceLevelMinusBaseline.php
+++ b/php-classes/Slate/CBL/Calculators/Growth/PerformanceLevelMinusBaseline.php
@@ -24,7 +24,7 @@ class PerformanceLevelMinusBaseline implements IGrowthCalculator
             }
         }
 
-        if ($skillsWithRatings * 2 < $StudentCompetency->Competency->getTotalSkills()) {
+        if ($skillsWithRatings === 0) {
             return false;
         } else {
             return $performanceLevel - $baseline;


### PR DESCRIPTION
fix: require only one rating in PLMB growth calculation
- `Performance Level Minus Baseline` (PLMB) growth should only require one rating and a baseline

Based on the definition of the growth in the [Growth Document](https://docs.google.com/document/d/17CyfP2tNVn6mRem_s8n5oT1IOwCLaiYvmxJIJE8N1fg):

<img width="673" alt="Screen Shot 2022-04-07 at 10 09 33 PM" src="https://user-images.githubusercontent.com/984849/162349921-4e32fe2b-b8a5-456d-86ab-2ca122ec9ce0.png">
