### PR TITLE
fix: filter inactive skills/competencies/areas out of most places

### DIFF
--- a/fixtures/cbl_competencies.sql
+++ b/fixtures/cbl_competencies.sql
@@ -57,8 +57,8 @@ INSERT INTO `cbl_competencies` VALUES (36,'Slate\\CBL\\Competency','2019-01-02 0
 INSERT INTO `cbl_competencies` VALUES (37,'Slate\\CBL\\Competency','2019-01-02 03:04:05',1,NULL,NULL,11,'WF.2','Wayfinding 2','During my second portfolio of Wayfinding, I will participate in career-connected studios and prepare for my Foundations Capstone.','active');
 INSERT INTO `cbl_competencies` VALUES (38,'Slate\\CBL\\Competency','2019-01-02 03:04:05',1,NULL,NULL,11,'WF.3','Wayfinding 3','During my third portfolio of Wayfinding, I will start to personalize my pathway and begin to create my post-secondary plan.','active');
 INSERT INTO `cbl_competencies` VALUES (39,'Slate\\CBL\\Competency','2019-01-02 03:04:05',1,NULL,NULL,11,'WF.4','Wayfinding 4','In my final Wayfinding portfolio, I will create my post-secondary plan and choose a passion project for my Design Capstone.','active');
-INSERT INTO `cbl_competencies` VALUES (40,'Slate\\CBL\\Competency','2021-08-08 17:14:42',1,NULL,NULL,12,'TEST.1','Test Competency','This is a test competency.','archived');
-INSERT INTO `cbl_competencies` VALUES (41,'Slate\\CBL\\Competency','2021-08-08 17:15:30',1,NULL,NULL,2,'HOS.5','HOS Test Competency','This is a test competency for HOS.','archived');
+INSERT INTO `cbl_competencies` VALUES (40,'Slate\\CBL\\Competency','2021-08-08 17:14:42',1,NULL,NULL,12,'TEST.1','Archived Competency','This is an archived competency.','archived');
+INSERT INTO `cbl_competencies` VALUES (41,'Slate\\CBL\\Competency','2021-08-08 17:15:30',1,NULL,NULL,2,'HOS.5','HOS Archived Competency','This is an archived competency for HOS.','archived');
 
 
 CREATE TABLE `history_cbl_competencies` (

--- a/fixtures/cbl_content_areas.sql
+++ b/fixtures/cbl_content_areas.sql
@@ -24,4 +24,4 @@ INSERT INTO `cbl_content_areas` VALUES (8,'Slate\\CBL\\ContentArea','2019-01-02 
 INSERT INTO `cbl_content_areas` VALUES (9,'Slate\\CBL\\ContentArea','2019-01-02 03:04:05',1,'SS','Social Studies','active');
 INSERT INTO `cbl_content_areas` VALUES (10,'Slate\\CBL\\ContentArea','2019-01-02 03:04:05',1,'VA','Visual Art','active');
 INSERT INTO `cbl_content_areas` VALUES (11,'Slate\\CBL\\ContentArea','2019-01-02 03:04:05',1,'WF','Wayfinding','active');
-INSERT INTO `cbl_content_areas` VALUES (12,'Slate\\CBL\\ContentArea','2021-08-08 17:14:02',1,'TEST','Test Area','archived');
+INSERT INTO `cbl_content_areas` VALUES (12,'Slate\\CBL\\ContentArea','2021-08-08 17:14:02',1,'TEST','Archived Area','archived');

--- a/fixtures/cbl_skills.sql
+++ b/fixtures/cbl_skills.sql
@@ -223,9 +223,9 @@ INSERT INTO `cbl_skills` VALUES (201,'Slate\\CBL\\Skill','2019-01-02 03:04:05',1
 INSERT INTO `cbl_skills` VALUES (202,'Slate\\CBL\\Skill','2019-01-02 03:04:05',1,'2021-05-14 22:28:44',NULL,39,'WF.4.3','Celebration of Learning','I willingly participate in Celebration of Learning events by exhibiting my learning as well as artifacts I create.','{\"9\": 0, \"10\": 0, \"11\": 0, \"12\": 1, \"default\": 1}','active');
 INSERT INTO `cbl_skills` VALUES (203,'Slate\\CBL\\Skill','2019-01-02 03:04:05',1,'2021-05-14 22:28:44',NULL,39,'WF.4.4','Exit Portfolio','I can document my best work, academic growth, and personal growth in a digital portfolio.','{\"9\": 0, \"10\": 0, \"11\": 0, \"12\": 1, \"default\": 1}','active');
 INSERT INTO `cbl_skills` VALUES (204,'Slate\\CBL\\Skill','2019-01-02 03:04:05',1,'2021-05-14 22:28:44',NULL,39,'WF.4.5','Design Capstone','I can identify a problem, issue, or challenge I am passionate about and then create and implement my solution in the world.','{\"9\": 0, \"10\": 0, \"11\": 0, \"12\": 1, \"default\": 1}','active');
-INSERT INTO `cbl_skills` VALUES (205,'Slate\\CBL\\Skill','2021-08-08 17:12:32',1,NULL,NULL,8,'HOS.1.5','HOS.1 Test Skill','This is a test skill for HOS.1.','{\"9\": 4, \"10\": 4, \"11\": 4, \"12\": 4, \"default\": 1}','archived');
-INSERT INTO `cbl_skills` VALUES (206,'Slate\\CBL\\Skill','2021-08-08 17:16:57',1,NULL,NULL,41,'HOS.5.1','HOS.5 Test Skill','This is a test skill for HOS.5.','{\"9\": 4, \"10\": 4, \"11\": 4, \"12\": 4, \"default\": 1}','archived');
-INSERT INTO `cbl_skills` VALUES (207,'Slate\\CBL\\Skill','2021-08-08 17:18:45',1,NULL,NULL,40,'TEST.1.1','TEST.1 Test Skill','This is a test skill for TEST.1.','{\"9\": 4, \"10\": 4, \"11\": 4, \"12\": 4, \"default\": 1}','archived');
+INSERT INTO `cbl_skills` VALUES (205,'Slate\\CBL\\Skill','2021-08-08 17:12:32',1,NULL,NULL,8,'HOS.1.5','HOS.1 Archived Skill','This is an archived skill for HOS.1.','{\"9\": 4, \"10\": 4, \"11\": 4, \"12\": 4, \"default\": 1}','archived');
+INSERT INTO `cbl_skills` VALUES (206,'Slate\\CBL\\Skill','2021-08-08 17:16:57',1,NULL,NULL,41,'HOS.5.1','HOS.5 Archived Skill','This is an archived skill for HOS.5.','{\"9\": 4, \"10\": 4, \"11\": 4, \"12\": 4, \"default\": 1}','archived');
+INSERT INTO `cbl_skills` VALUES (207,'Slate\\CBL\\Skill','2021-08-08 17:18:45',1,NULL,NULL,40,'TEST.1.1','TEST.1 Archived Skill','This is an archived skill for TEST.1.','{\"9\": 4, \"10\": 4, \"11\": 4, \"12\": 4, \"default\": 1}','archived');
 
 
 CREATE TABLE `history_cbl_skills` (

--- a/html-templates/cbl/student-competencies/studentCompetency.tpl
+++ b/html-templates/cbl/student-competencies/studentCompetency.tpl
@@ -15,7 +15,9 @@
         {dli label=Creator value=$data->Creator->getTitle() url=$data->Creator->getUrl()}
         {dli label=Student value=$data->Student->getTitle() url=$data->Student->getUrl()}
         {dli label=Competency value=$data->Competency->getTitle() url=$data->Competency->getUrl()}
+        {dli label='Competency Status' value=$data->Competency->Status}
         {dli label='Content Area' value=$data->Competency->ContentArea->getTitle() url=$data->Competency->ContentArea->getUrl()}
+        {dli label='Content Area Status' value=$data->Competency->->ContentArea->Status}
         {dli label=Level value=$data->Level}
         {dli label='Entered Via' value=$data->EnteredVia}
         {dli label='Baseline Rating' value=$data->BaselineRating}

--- a/html-templates/cbl/student-competencies/studentCompetency.tpl
+++ b/html-templates/cbl/student-competencies/studentCompetency.tpl
@@ -41,38 +41,42 @@
     ?>
 
     <h3>Skill Demonstrations</h3>
-    <table class="auto-width row-stripes row-highlight">
-        <thead>
-            <tr>
-                <th scope="col">ID</th>
-                <th scope="col">Created</th>
-                <th scope="col">Creator</th>
-                <th scope="col">Demonstration</th>
-                <th scope="col">DemonstrationDate</th>
-                <th scope="col">Level</th>
-                <th scope="col">Rating</th>
-                <th scope="col">Override</th>
-            </tr>
-        </thead>
-        <tbody>
-        {foreach item=demonstrationSkills key=skillId from=$data->getDemonstrationData()}
-            <tr>
-                <th colspan="8">{contextLink Slate\CBL\Skill::getById($skillId)}</th>
-            </tr>
-            {foreach item=DemonstrationSkill from=$demonstrationSkills}
-                {$Demonstration = Slate\CBL\Demonstrations\Demonstration::getById($DemonstrationSkill.DemonstrationID)}
-                <tr class="{tif $DemonstrationSkill.ID|in_array:$effectiveDemonstrationSkillIds ? effective : muted}">
-                    <td>#{$DemonstrationSkill.ID}</td>
-                    <td>{$DemonstrationSkill.Created|date_format}</td>
-                    <td>{contextLink Emergence\People\Person::getById($DemonstrationSkill.CreatorID)}</td>
-                    <td><a href="{$Demonstration->getUrl()|escape}">#{$Demonstration->ID}</a></td>
-                    <td>{$DemonstrationSkill.DemonstrationDate|date_format}</td>
-                    <td>{$DemonstrationSkill.TargetLevel}</td>
-                    <td>{tif $DemonstrationSkill.DemonstratedLevel == '0' ? 'M' : $DemonstrationSkill.DemonstratedLevel}</td>
-                    <td>{tif($DemonstrationSkill.Override, 'Yes', 'No')}</td>
+    {if $data->Competency->Status == 'active'}
+        <table class="auto-width row-stripes row-highlight">
+            <thead>
+                <tr>
+                    <th scope="col">ID</th>
+                    <th scope="col">Created</th>
+                    <th scope="col">Creator</th>
+                    <th scope="col">Demonstration</th>
+                    <th scope="col">DemonstrationDate</th>
+                    <th scope="col">Level</th>
+                    <th scope="col">Rating</th>
+                    <th scope="col">Override</th>
                 </tr>
+            </thead>
+            <tbody>
+            {foreach item=demonstrationSkills key=skillId from=$data->getDemonstrationData()}
+                <tr>
+                    <th colspan="8">{contextLink Slate\CBL\Skill::getById($skillId)}</th>
+                </tr>
+                {foreach item=DemonstrationSkill from=$demonstrationSkills}
+                    {$Demonstration = Slate\CBL\Demonstrations\Demonstration::getById($DemonstrationSkill.DemonstrationID)}
+                    <tr class="{tif $DemonstrationSkill.ID|in_array:$effectiveDemonstrationSkillIds ? effective : muted}">
+                        <td>#{$DemonstrationSkill.ID}</td>
+                        <td>{$DemonstrationSkill.Created|date_format}</td>
+                        <td>{contextLink Emergence\People\Person::getById($DemonstrationSkill.CreatorID)}</td>
+                        <td><a href="{$Demonstration->getUrl()|escape}">#{$Demonstration->ID}</a></td>
+                        <td>{$DemonstrationSkill.DemonstrationDate|date_format}</td>
+                        <td>{$DemonstrationSkill.TargetLevel}</td>
+                        <td>{tif $DemonstrationSkill.DemonstratedLevel == '0' ? 'M' : $DemonstrationSkill.DemonstratedLevel}</td>
+                        <td>{tif($DemonstrationSkill.Override, 'Yes', 'No')}</td>
+                    </tr>
+                {/foreach}
             {/foreach}
-        {/foreach}
-        </tbody>
-    </table>
+            </tbody>
+        </table>
+    {else}
+        <p><em>Demonstration data unavailable because this competency is <strong>{$data->Competency->Status}</strong></em></p>
+    {/if}
 {/block}

--- a/php-classes/Slate/CBL/Competency.php
+++ b/php-classes/Slate/CBL/Competency.php
@@ -57,10 +57,10 @@ class Competency extends \VersionedRecord
     public static $dynamicFields = [
         'ContentArea',
         'Skills' => [
-            'getter' => 'getSkills'
+            'getter' => 'getActiveSkills'
         ],
         'skillIds' => [
-            'getter' => 'getSkillIds'
+            'getter' => 'getActiveSkillIds'
         ],
         'totalDemonstrationsRequired' => [
             'getter' => 'getTotalDemonstrationsRequired'
@@ -118,24 +118,48 @@ class Competency extends \VersionedRecord
         return $this->finishValidation();
     }
 
-    public function getSkillIds($forceRefresh = false)
+    public function save($deep = true)
     {
-        $cacheKey = "cbl-competency/$this->ID/skill-ids";
+        $wasContentAreaDirty = $this->isFieldDirty('ContentAreaID');
+        $wasStatusDirty = $this->isFieldDirty('Status');
+
+        parent::save($deep);
+
+        if ($wasContentAreaDirty || $wasStatusDirty) {
+            if ($this->ContentArea) {
+                $this->ContentArea->getActiveSkillIds(true); // true to force refresh of cached value
+            }
+        }
+
+        if ($wasContentAreaDirty) {
+            if ($oldContentAreaId = $this->getOriginalValue('ContentAreaID')) {
+                ContentArea::getByID($oldContentAreaId)->getActiveSkillIds(true); // true to force refresh of cached value
+            }
+        }
+    }
+
+    public function getActiveSkillIds($forceRefresh = false)
+    {
+        $cacheKey = "cbl-competency/$this->ID/active-skill-ids";
 
         if (!$forceRefresh && false !== ($skillIds = Cache::fetch($cacheKey))) {
             return $skillIds;
         }
 
-        try {
-            $skillIds = array_map('intval', DB::allValues(
-                'ID',
-                'SELECT ID FROM `%s` WHERE CompetencyID = %u',
-                [
-                    Skill::$tableName,
-                    $this->ID
-                ]
-            ));
-        } catch (TableNotFoundException $e) {
+        if ($this->Status == 'active') {
+            try {
+                $skillIds = array_map('intval', DB::allValues(
+                    'ID',
+                    'SELECT ID FROM `%s` WHERE CompetencyID = %u AND Status = "active"',
+                    [
+                        Skill::$tableName,
+                        $this->ID
+                    ]
+                ));
+            } catch (TableNotFoundException $e) {
+                $skillIds = [];
+            }
+        } else {
             $skillIds = [];
         }
 
@@ -144,11 +168,11 @@ class Competency extends \VersionedRecord
         return $skillIds;
     }
 
-    public function getSkills($forceRefresh = false)
+    public function getActiveSkills($forceRefresh = false)
     {
         $skills = [];
 
-        foreach (static::getSkillIds($forceRefresh) as $skillId) {
+        foreach (static::getActiveSkillIds($forceRefresh) as $skillId) {
             $skills[] = Skill::getByID($skillId);
         }
 
@@ -159,7 +183,7 @@ class Competency extends \VersionedRecord
     public function getTotalSkills($forceRefresh = false)
     {
         if ($this->totalSkills === null || $forceRefresh) {
-            $this->totalSkills = count($this->getSkillIds($forceRefresh));
+            $this->totalSkills = count($this->getActiveSkillIds($forceRefresh));
         }
 
         return $this->totalSkills;
@@ -171,7 +195,7 @@ class Competency extends \VersionedRecord
 
         if ($forceRefresh || false === ($levelTotals = Cache::fetch($cacheKey))) {
             try {
-                $skills = $this->getSkills();
+                $skills = $this->getActiveSkills();
 
                 // accumulate available levels
                 $collectedLevel = [];

--- a/php-classes/Slate/CBL/ContentArea.php
+++ b/php-classes/Slate/CBL/ContentArea.php
@@ -44,10 +44,10 @@ class ContentArea extends \ActiveRecord
 
     public static $dynamicFields = [
         'Competencies' => [
-            'getter' => 'getCompetencies'
+            'getter' => 'getActiveCompetencies'
         ],
         'competencyIds' => [
-            'getter' => 'getCompetencyIds'
+            'getter' => 'getActiveCompetencyIds'
         ],
     ];
 
@@ -73,9 +73,9 @@ class ContentArea extends \ActiveRecord
         return $title;
     }
 
-    public function getCompetencyIds($forceRefresh = false)
+    public function getActiveCompetencyIds($forceRefresh = false)
     {
-        $cacheKey = "cbl-contentarea/$this->ID/competency-ids";
+        $cacheKey = "cbl-contentarea/$this->ID/active-competency-ids";
 
         if (!$forceRefresh && false !== ($competencyIds = Cache::fetch($cacheKey))) {
             return $competencyIds;
@@ -84,7 +84,7 @@ class ContentArea extends \ActiveRecord
         try {
             $competencyIds = array_map('intval', DB::allValues(
                 'ID',
-                'SELECT ID FROM `%s` WHERE ContentAreaID = %u',
+                'SELECT ID FROM `%s` WHERE ContentAreaID = %u AND Status = "active"',
                 [
                     Competency::$tableName,
                     $this->ID
@@ -99,20 +99,20 @@ class ContentArea extends \ActiveRecord
         return $competencyIds;
     }
 
-    public function getCompetencies($forceRefresh = false)
+    public function getActiveCompetencies($forceRefresh = false)
     {
         $competencies = [];
 
-        foreach (static::getCompetencyIds($forceRefresh) as $competencyId) {
+        foreach (static::getActiveCompetencyIds($forceRefresh) as $competencyId) {
             $competencies[] = Competency::getByID($competencyId);
         }
 
         return $competencies;
     }
 
-    public function getSkillIds($forceRefresh = false)
+    public function getActiveSkillIds($forceRefresh = false)
     {
-        $cacheKey = "cbl-contentarea/$this->ID/skill-ids";
+        $cacheKey = "cbl-contentarea/$this->ID/active-skill-ids";
 
         if (!$forceRefresh && false !== ($skillIds = Cache::fetch($cacheKey))) {
             return $skillIds;
@@ -127,6 +127,8 @@ class ContentArea extends \ActiveRecord
                       JOIN `%s` Competency
                         ON Competency.ID = Skill.CompetencyID
                      WHERE Competency.ContentAreaID = %u
+                       AND Competency.Status = "active"
+                       AND Skill.Status = "active"
                 ',
                 [
                     Skill::$tableName,
@@ -143,11 +145,11 @@ class ContentArea extends \ActiveRecord
         return $skillIds;
     }
 
-    public function getSkills($forceRefresh = false)
+    public function getActiveSkills($forceRefresh = false)
     {
         $skills = [];
 
-        foreach (static::getSkillIds($forceRefresh) as $skillId) {
+        foreach (static::getActiveSkillIds($forceRefresh) as $skillId) {
             $skills[] = Skill::getByID($skillId);
         }
 

--- a/php-classes/Slate/CBL/Demonstrations/DemonstrationSkillsRequestHandler.php
+++ b/php-classes/Slate/CBL/Demonstrations/DemonstrationSkillsRequestHandler.php
@@ -47,18 +47,18 @@ class DemonstrationSkillsRequestHandler extends \Slate\CBL\RecordsRequestHandler
                 return $Skill->ID;
             }, $skills);
         } elseif ($Competency = static::getRequestedCompetency()) {
-            $skillIds = $Competency->getSkillIds();
+            $skillIds = $Competency->getActiveSkillIds();
             $filterObjects['Competency'] = $Competency;
         } elseif ($competencies = static::getRequestedCompetencies()) {
             $skillIds = [];
 
             foreach ($competencies as $Competency) {
-                $skillIds = array_merge($skillIds, $Competency->getSkillIds());
+                $skillIds = array_merge($skillIds, $Competency->getActiveSkillIds());
             }
 
             $skillIds = array_unique($skillIds);
         } elseif ($ContentArea = static::getRequestedContentArea()) {
-            $skillIds = $ContentArea->getSkillIds();
+            $skillIds = $ContentArea->getActiveSkillIds();
             $filterObjects['ContentArea'] = $ContentArea;
         } else {
             $skillIds = null;

--- a/php-classes/Slate/CBL/Demonstrations/DemonstrationsRequestHandler.php
+++ b/php-classes/Slate/CBL/Demonstrations/DemonstrationsRequestHandler.php
@@ -48,18 +48,18 @@ class DemonstrationsRequestHandler extends \Slate\CBL\RecordsRequestHandler
                 return $Skill->ID;
             }, $skills);
         } elseif ($Competency = static::getRequestedCompetency()) {
-            $skillIds = $Competency->getSkillIds();
+            $skillIds = $Competency->getActiveSkillIds();
             $filterObjects['Competency'] = $Competency;
         } elseif ($competencies = static::getRequestedCompetencies()) {
             $skillIds = [];
 
             foreach ($competencies as $Competency) {
-                $skillIds = array_merge($skillIds, $Competency->getSkillIds());
+                $skillIds = array_merge($skillIds, $Competency->getActiveSkillIds());
             }
 
             $skillIds = array_unique($skillIds);
         } elseif ($ContentArea = static::getRequestedContentArea()) {
-            $skillIds = $ContentArea->getSkillIds();
+            $skillIds = $ContentArea->getActiveSkillIds();
             $filterObjects['ContentArea'] = $ContentArea;
         } else {
             $skillIds = null;

--- a/php-classes/Slate/CBL/Demonstrations/StudentDashboardRequestHandler.php
+++ b/php-classes/Slate/CBL/Demonstrations/StudentDashboardRequestHandler.php
@@ -9,7 +9,7 @@ use Emergence\People\Person;
 use Emergence\WebApps\SenchaApp;
 
 use Slate\CBL\RecordsRequestHandler as CBLRecordsRequestHandler;
-use Slate\CBL\ContentAreasRequestHandler;
+use Slate\CBL\ContentArea;
 use Slate\CBL\Competency;
 use Slate\CBL\Skill;
 
@@ -65,7 +65,10 @@ class StudentDashboardRequestHandler extends \Emergence\Site\RequestHandler
 
         // build conditions
         $where = [
-            'd.StudentID = ' . $Student->ID
+            'd.StudentID = ' . $Student->ID,
+            's.Status = "active"',
+            'c.Status = "active"',
+            'ca.Status = "active"'
         ];
 
         if ($ContentArea) {
@@ -103,6 +106,8 @@ class StudentDashboardRequestHandler extends \Emergence\Site\RequestHandler
                     ON s.ID = ds.SkillID
                   JOIN %s AS c
                     ON c.ID = s.CompetencyID
+                  JOIN %s AS ca
+                    ON ca.ID = c.ContentAreaID
                   WHERE (%s)
                   ORDER BY d.ID DESC
                   LIMIT %d',
@@ -112,6 +117,7 @@ class StudentDashboardRequestHandler extends \Emergence\Site\RequestHandler
                     Demonstration::$tableName,
                     Skill::$tableName,
                     Competency::$tableName,
+                    ContentArea::$tableName,
                     count($where) ? implode(') AND (', $where) : 'TRUE',
                     $limit
                 ]

--- a/php-classes/Slate/CBL/Skill.php
+++ b/php-classes/Slate/CBL/Skill.php
@@ -119,17 +119,27 @@ class Skill extends \VersionedRecord
     public function save($deep = true)
     {
         $wasCompetencyDirty = $this->isFieldDirty('CompetencyID');
+        $wasStatusDirty = $this->isFieldDirty('Status');
         $wasDemonstrationsRequiredDirty = $this->isFieldDirty('DemonstrationsRequired');
 
         parent::save($deep);
 
-        if ($wasCompetencyDirty) {
+        if ($wasCompetencyDirty || $wasStatusDirty) {
             if ($this->Competency) {
-                $this->Competency->getSkillIds(true); // true to force refresh of cached value
+                $this->Competency->getActiveSkillIds(true); // true to force refresh of cached value
+                if ($this->Competency->ContentArea) {
+                    $this->Competency->ContentArea->getActiveSkillIds(true); // true to force refresh of cached value
+                }
             }
+        }
 
+        if ($wasCompetencyDirty) {
             if ($oldCompetencyId = $this->getOriginalValue('CompetencyID')) {
-                Competency::getByID($oldCompetencyId)->getSkillIds(true); // true to force refresh of cached value
+                $oldCompetency = Competency::getByID($oldCompetencyId);
+                $oldCompetency->getActiveSkillIds(true); // true to force refresh of cached value
+                if ($oldCompetency->ContentArea) {
+                    $oldCompetency->ContentArea->getActiveSkillIds(true); // true to force refresh of cached value
+                }
             }
         }
 

--- a/php-classes/Slate/CBL/SkillsRequestHandler.php
+++ b/php-classes/Slate/CBL/SkillsRequestHandler.php
@@ -28,7 +28,7 @@ class SkillsRequestHandler extends RecordsRequestHandler
                 }, $competencies)
             ];
         } elseif ($ContentArea = static::getRequestedContentArea()) {
-            $conditions['CompetencyID'] = [ 'values' => $ContentArea->getCompetencyIds() ];
+            $conditions['CompetencyID'] = [ 'values' => $ContentArea->getActiveCompetencyIds() ];
             $filterObjects['ContentArea'] = $ContentArea;
         }
 

--- a/php-classes/Slate/CBL/StudentCompetenciesRequestHandler.php
+++ b/php-classes/Slate/CBL/StudentCompetenciesRequestHandler.php
@@ -78,7 +78,7 @@ class StudentCompetenciesRequestHandler extends RecordsRequestHandler
                 }, $competencies)
             ];
         } elseif ($ContentArea = static::getRequestedContentArea()) {
-            $conditions['CompetencyID'] = [ 'values' => $ContentArea->getCompetencyIds() ];
+            $conditions['CompetencyID'] = [ 'values' => $ContentArea->getActiveCompetencyIds() ];
             $filterObjects['ContentArea'] = $ContentArea;
         }
 

--- a/php-classes/Slate/CBL/StudentCompetency.php
+++ b/php-classes/Slate/CBL/StudentCompetency.php
@@ -215,7 +215,7 @@ class StudentCompetency extends \ActiveRecord
         if ($this->demonstrationData === null) {
             // TODO: cache dynamically
             try {
-                $skillIds = $this->Competency->getSkillIds();
+                $skillIds = $this->Competency->getActiveSkillIds();
 
                 if (count($skillIds)) {
                     $conditions = [


### PR DESCRIPTION
In #584 some initial work was merged in to add a "status" field to ContentArea/Competency/Skill models and exclude them from reports. It also added some test content for all three models in the `archived` status

Some of the added archived content threw off growth measures in one case, making me notice that we weren't really handling these new statuses internally at all

This set of changes causes inactive ContentArea/Competency/Skill models **and any associated ratings** to be filtered out in most places. Any ratings associated with archived content will not be visible in UIs or count towards progress/growth. This complete exclusion proved necessary, because otherwise numerators and denominators could not line up logically.

This means that other methods must be implemented in the future for identifying and dealing with ratings under archived ContentArea/Competency/Skill models, as for most intents and purposes within CBL user workflows and data they will become invisible and treated as nonexistent.