### PR TITLE
fix: update growth calculation and tests

### DIFF
--- a/.holo/sources/slate.toml
+++ b/.holo/sources/slate.toml
@@ -1,3 +1,3 @@
 [holosource]
 url = "https://github.com/SlateFoundation/slate"
-ref = "refs/tags/v2.18.10"
+ref = "refs/tags/v2.18.11"

--- a/.holo/sources/slate.toml
+++ b/.holo/sources/slate.toml
@@ -1,3 +1,3 @@
 [holosource]
 url = "https://github.com/SlateFoundation/slate"
-ref = "refs/tags/v2.18.9"
+ref = "refs/tags/v2.18.10"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -62,6 +62,18 @@
             "port": 9222,
             "webRoot": "${workspaceFolder}/sencha-workspace",
             "url": "http://localhost:7081"
-        }
+        },
+        {
+            "type": "chrome",
+            "request": "attach",
+            "name": "Attach to Cypress Chrome",
+            "port": 9222,
+            "urlFilter": "http://localhost*",
+            "webRoot": "${workspaceFolder}/../slate-cbl.cypress-workspace/merged/",
+            "sourceMaps": true,
+            "skipFiles": [
+                "cypress_runner.js",
+            ],
+        },
     ]
 }

--- a/cypress/fixtures/student-competency-calculations.json
+++ b/cypress/fixtures/student-competency-calculations.json
@@ -193,7 +193,7 @@
                 "baseline":null,
                 "average":null,
                 "growth":"0",
-                "progress":"0"       
+                "progress":"0"
             }
         },
         "NGE":{
@@ -208,8 +208,8 @@
             "HOS.1":{
                 "baseline":null,
                 "average":"9.1",
-                "growth":"0",
-                "progress":"45"
+                "growth":"2.5",
+                "progress":"56"
             }
         },
         "HW":{
@@ -257,19 +257,19 @@
                 "baseline":"5",
                 "average":"7.5",
                 "growth":"2.5",
-                "progress":"100"              
+                "progress":"100"
             },
             "ELA.5":{
                 "baseline":"5",
                 "average":"7",
                 "growth":"2",
-                "progress":"83"              
+                "progress":"83"
             },
             "ELA.6":{
                 "baseline":"5",
                 "average":"8",
                 "growth":"3",
-                "progress":"33"              
+                "progress":"33"
             },
             "ELA.7":{
                 "baseline":"5",

--- a/cypress/fixtures/student-competency-calculations.json
+++ b/cypress/fixtures/student-competency-calculations.json
@@ -2,6 +2,7 @@
     "student": {
         "ELA": {
             "ELA.1": {
+                "description": "One rating for each skill",
                 "baseline": "10",
                 "average": "9.3",
                 "averageExplanation": "ELA.1 for student has Performance Level 9.3 ((8+9+10+10)/4 = 9.25 rounded to 9.3)",
@@ -11,6 +12,7 @@
                 "progressExplanation": "ELA.1 for student has 33% Progress (4/12 Demonstrations Required for Competency)"
             },
             "ELA.2": {
+                "description": "One rating for all but one skill",
                 "baseline": "10",
                 "average": "10.8",
                 "averageExplanation": "ELA.2 for student has Performance Level 9.3 ((11+11+11+10)/4 = 10.75 rounded to 10.8)",
@@ -20,6 +22,7 @@
                 "progressExplanation": "ELA.2 for student has 33% Progress (4/15 Demonstrations Required for Competency)"
             },
             "ELA.6": {
+                "description": "More than 1 rating",
                 "baseline": "9.5",
                 "average": "10",
                 "growth": "1.5",
@@ -30,12 +33,14 @@
     "student2":{
         "ELA":{
             "ELA.2":{
+                "description": "All Ms. There are ratings but there is no performance level",
                 "baseline":"9",
                 "average":null,
                 "growth": "0",
                 "progress":"0"
             },
             "ELA.3":{
+                "description": "Performance level and baseline are the same",
                 "baseline":"9",
                 "average":"9",
                 "growth": "0",
@@ -44,84 +49,30 @@
         }
     },
     "student3": {
-        "ELA": {
-            "ELA.1": {
-                "baseline": "7.3",
-                "average": "7.3",
-                "growth": "0",
-                "progress": "33"
-            },
-            "ELA.2": {
-                "baseline": null,
-                "average": "7.3",
-                "growth": "0",
-                "progress": "40"
-            },
-            "ELA.3": {
-                "baseline": "5.5",
-                "average": "8",
-                "growth": "2.5",
-                "progress": "100"
-            },
-            "ELA.4": {
-                "baseline": "5.7",
-                "average": "6.5",
-                "growth": "0.8",
-                "progress": "100"
-            },
-            "ELA.5": {
-                "baseline": null,
-                "average": "7.4",
-                "growth": "0",
-                "progress": "83"
-            },
-            "ELA.6": {
-                "baseline": null,
-                "average": "8",
-                "growth": "0",
-                "progress": "33"
-            },
-            "ELA.7": {
-                "baseline": "7",
-                "average": "7.4",
-                "growth": "0.7",
-                "progress": "63"
-            }
-        },
-        "SS": {
-            "SS.1": {
-                "baseline": "9.4",
-                "average": "9",
-                "growth": "-0.4",
-                "progress": "40"
-            },
-            "SS.2": {
-                "baseline": null,
-                "average": "8",
-                "growth": "0",
-                "progress": "50"
-            }
-        },
         "SCI": {
             "SCI.1": {
+                "description": "One full ER plus one additional rating, less than 50%",
                 "baseline": "9.1",
                 "average": "9.4",
                 "growth": "0.4",
                 "progress": "38"
             },
             "SCI.2": {
+                "description": "One rating",
                 "baseline": "9.3",
                 "average": "8",
                 "growth": "-1.3",
                 "progress": "25"
             },
             "SCI.3": {
+                "description": "One rating",
                 "baseline": "9.7",
                 "average": "7",
                 "growth": "0",
                 "progress": "33"
             },
             "SCI.4": {
+                "description": "More than 1 rating",
                 "baseline": "9.7",
                 "average": "10",
                 "growth": "0.3",
@@ -130,6 +81,7 @@
         },
         "HOS": {
             "HOS.4": {
+                "description": "One set of ERs thats low and hidden and one that is higher and displayed",
                 "baseline": "9",
                 "average": "9.3",
                 "growth": "0",
@@ -140,42 +92,49 @@
     "student4":{
         "ELA":{
             "ELA.1":{
+                "description": "One rating for each skill",
                 "baseline":null,
                 "average":"6",
                 "growth":"0" ,
                 "progress":"33"
             },
             "ELA.2":{
+                "description": "One rating for all but one skill, progress < 50%",
                 "baseline":null,
                 "average":"6",
                 "growth":"0" ,
                 "progress":"40"
             },
             "ELA.3":{
+                "description": "One set of ERs thats low and hidden and one that is higher and displayed",
                 "baseline":null,
                 "average":"7",
                 "growth":"1" ,
                 "progress":"100"
             },
             "ELA.4":{
+                "description": "One set of ER thats low and hidden and one that is higher and displayed with Ms",
                 "baseline":null,
                 "average":"6.7",
                 "growth":"1" ,
                 "progress":"100"
             },
             "ELA.5":{
+                "description": "No full set of ER, Progress > 50%",
                 "baseline":null,
                 "average":"7",
                 "growth":"1" ,
                 "progress":"83"
             },
             "ELA.6":{
+                "description": "One rating for each skill except one which is an M",
                 "baseline":null,
                 "average":"7",
                 "growth":"0" ,
                 "progress":"33"
             },
             "ELA.7":{
+                "description": "One full ER plus one additional rating",
                 "baseline":null,
                 "average":"6.4",
                 "growth":"0",
@@ -184,12 +143,14 @@
         },
         "SCI":{
             "SCI.1":{
+                "description": "One full ER plus one additional rating, less than 50%",
                 "baseline":null,
                 "average":"6.6",
                 "growth":"0",
                 "progress":"38"
             },
             "SCI.3":{
+                "description": "All Ms",
                 "baseline":null,
                 "average":null,
                 "growth":"0",
@@ -198,6 +159,7 @@
         },
         "NGE":{
             "NGE.1":{
+                "description": "No full set of ERs, Progress < 50%",
                 "baseline":null,
                 "average":"9.4",
                 "growth":"-1.3",
@@ -206,6 +168,7 @@
         },
         "HOS":{
             "HOS.1":{
+                "description": "No full set of ER, Progress >= 50%",
                 "baseline":null,
                 "average":"9.1",
                 "growth":"2.5",
@@ -214,18 +177,21 @@
         },
         "HW":{
             "HW.1":{
+                "description": "One full ER, HW.1.4 is set to zero ER",
                 "baseline":null,
                 "average":"8",
                 "growth":"0",
                 "progress":"33"
             },
             "HW.2":{
+                "description": "No full set of ER, HW.2.5 is set to zero ER, Progress < 50%",
                 "baseline":null,
                 "average":"8.4",
                 "growth":"0",
                 "progress":"42"
             },
             "HW.3":{
+                "description": "No full set of ER, HW3.4 is set to zero ER, Progress >= 50%",
                 "baseline":null,
                 "average":"9.2",
                 "growth":"2.5",
@@ -236,42 +202,49 @@
     "student5":{
         "ELA":{
             "ELA.1":{
+                "description": "One rating for each skill",
                 "baseline":"5",
                 "average":"6.5",
                 "growth":"1.5",
                 "progress":"33"
             },
             "ELA.2":{
+                "description": "One rating for all but one skill, progress < 50%",
                 "baseline":"5",
                 "average":"7",
                 "growth":"2",
                 "progress":"40"
             },
             "ELA.3":{
+                "description": "One set of ERs thats low and hidden and one that is higher and displayed",
                 "baseline":"5",
                 "average":"8.2",
                 "growth":"3.2",
                 "progress":"100"
             },
             "ELA.4":{
+                "description": "One set of ER thats low and hidden and one that is higher and displayed with Ms",
                 "baseline":"5",
                 "average":"7.5",
                 "growth":"2.5",
                 "progress":"100"
             },
             "ELA.5":{
+                "description": "No full set of ER, Progress > 50%",
                 "baseline":"5",
                 "average":"7",
                 "growth":"2",
                 "progress":"83"
             },
             "ELA.6":{
+                "description": "One rating for each skill except one which is an M",
                 "baseline":"5",
                 "average":"8",
                 "growth":"3",
                 "progress":"33"
             },
             "ELA.7":{
+                "description": "One full ER plus one additional rating",
                 "baseline":"5",
                 "average":"6.2",
                 "growth":"1.3",

--- a/cypress/integration/api/student-competencies.js
+++ b/cypress/integration/api/student-competencies.js
@@ -20,15 +20,15 @@ describe('/cbl/student-competencies API', () => {
             expect(response.body).property('data').to.be.an('array');
             expect(response.body.data).to.have.length(643);
             expect(response.body.data[0]).to.include({
-                ID: 643,
+                ID: 584,
                 Class: 'Slate\\CBL\\StudentCompetency',
-                Created: 1637588605,
+                Created: 1622423774,
                 CreatorID: 2,
-                StudentID: 6,
-                CompetencyID: 32,
-                Level: 9,
+                StudentID: 11,
+                CompetencyID: 20,
+                Level: 12,
                 EnteredVia: 'enrollment',
-                BaselineRating: null
+                BaselineRating: 0
             });
 
         });

--- a/cypress/integration/student-competency-calculations.js
+++ b/cypress/integration/student-competency-calculations.js
@@ -159,15 +159,16 @@ describe('Check UI data against test cases', () => {
                 cy.intercept('/cbl/student-competencies?*').as('getStudentCompetencies');
                 cy.visit(`/cbl/dashboards/demonstrations/student#${studentUsername}/${contentArea}`);
                 cy.wait('@getStudentCompetencies');
-                cy.withExt().then(({extQuerySelector}) => {
-                    // check each test case
-                    for (const competency in competencyTestCases) {
-                        const testCase = competencyTestCases[competency];
 
-                        const cardCmp = extQuerySelector(`slate-demonstrations-student-competencycard{getCompetency().get("Code")=="${competency}"}`);
-                        expect(cardCmp, testCase.description).to.be.an('object').that.has.property('xtype', 'slate-demonstrations-student-competencycard');
+                // check each test case
+                for (const competency in competencyTestCases) {
+                    const testCase = competencyTestCases[competency];
 
-                        cy.get(`#${cardCmp.id}`).within(() => {
+                    cy.log(testCase.description);
+
+                    cy.extGet(`slate-demonstrations-student-competencycard{getCompetency().get("Code")=="${competency}"}`)
+                        .should('have.nested.property', 'el.dom')
+                        .within(() => {
                             cy.get('span[data-ref="codeEl"]')
                                 .should('have.text', competency);
 
@@ -182,9 +183,8 @@ describe('Check UI data against test cases', () => {
 
                             cy.get('td[data-ref="growthEl"]')
                                 .should('have.text', testCase.growth === null ? '—' : `${testCase.growth <= 0 ? '' : '+'}${testCase.growth}`);
-                        });
-                    }
-                });
+                    });
+                }
             });
         }
     }

--- a/cypress/integration/student-competency-calculations.js
+++ b/cypress/integration/student-competency-calculations.js
@@ -47,7 +47,7 @@ describe('Check API data against test cases', () => {
                     for (const competency in competencyTestCases) {
                         const testCase = competencyTestCases[competency];
 
-                        expect(latestByCompetency).to.have.property(competency);
+                        expect(latestByCompetency, testCase.description).to.have.property(competency);
                         const latest = latestByCompetency[competency];
 
                         expect(

--- a/cypress/integration/student_tasks.js
+++ b/cypress/integration/student_tasks.js
@@ -61,12 +61,12 @@ describe('Student Tasks test', () => {
     });
 
     beforeEach(() => {
-        cy.intercept('GET', '/cbl/dashboards/tasks/student/bootstrap*').as('bootstrapData');
-        cy.intercept('GET', '/cbl/skills*').as('skillsData');
-        cy.intercept('GET', '/cbl/competencies*').as('competenciesData');
-        cy.intercept('GET', '/cbl/student-tasks*').as('studentTasksData');
-        cy.intercept('GET', '/cbl/todos/*groups*').as('studentTodosData');
-        cy.intercept('POST', '/cbl/student-tasks/save*').as('studentTasksSave');
+        cy.intercept('GET', '/cbl/dashboards/tasks/student/bootstrap?*').as('bootstrapData');
+        cy.intercept('GET', '/cbl/skills?*').as('skillsData');
+        cy.intercept('GET', '/cbl/competencies?*').as('competenciesData');
+        cy.intercept('GET', '/cbl/student-tasks?*').as('studentTasksData');
+        cy.intercept('GET', '/cbl/todos/\\*groups?*').as('studentTodosData');
+        cy.intercept('POST', '/cbl/student-tasks/save?*').as('studentTasksSave');
     });
 
     const _visitDashboardAsStudent = (student = 'student') => {
@@ -228,9 +228,13 @@ describe('Student Tasks test', () => {
                             .contains('Revision Workflow')
                             .click({ force: true })
 
+                        cy.wait('@studentTasksData')
+                            .its('response.statusCode')
+                            .should('eq', 200);
+
                         cy.get('.slate-window')
                             .contains('label', 'Re-assign')
-                            .click()
+                            .click();
 
                         cy.get('.slate-window')
                             .contains('Save Assignment')

--- a/data-exporters/slate-cbl/student-competencies.php
+++ b/data-exporters/slate-cbl/student-competencies.php
@@ -139,7 +139,7 @@ return [
                     'StudentFullName' => $Student->FullName,
                     'CompetencyCode' => $StudentCompetency->Competency->Code,
                     'Level' => $StudentCompetency->Level,
-                    'BaselineRating' => $StudentCompetency->getBaselineRating(),
+                    'BaselineRating' => $StudentCompetency->getBaselineAverage(),
                     'DemonstrationsAverage' => $StudentCompetency->getDemonstrationsAverage(),
                     'Growth' => $StudentCompetency->getGrowth(),
                     'Progress' => $StudentCompetency->getProgress(),

--- a/html-templates/cbl/student-competencies/studentCompetencies.tpl
+++ b/html-templates/cbl/student-competencies/studentCompetencies.tpl
@@ -77,6 +77,8 @@
                 <th scope="col">Level</th>
                 <th scope="col">Entered Via</th>
                 <th scope="col">Baseline Rating</th>
+                <th scope="col">Growth</th>
+                <th scope="col">Progress</th>
             </tr>
         </thead>
         <tbody>
@@ -87,7 +89,9 @@
                 <td>{contextLink $StudentCompetency->Competency}</td>
                 <td>{$StudentCompetency->Level}</td>
                 <td>{$StudentCompetency->EnteredVia|escape}</td>
-                <td>{$StudentCompetency->BaselineRating|escape|default:'&mdash;'}</td>
+                <td>{$StudentCompetency->BaselineRating|default:'&mdash;'}</td>
+                <td>{$StudentCompetency->getGrowth()|default:'&mdash;'}</td>
+                <td>{$StudentCompetency->getProgress()|default:'&mdash;'}</td>
             </tr>
         {/foreach}
         </tbody>

--- a/html-templates/cbl/student-competencies/studentCompetency.tpl
+++ b/html-templates/cbl/student-competencies/studentCompetency.tpl
@@ -21,8 +21,9 @@
         {dli label=Level value=$data->Level}
         {dli label='Entered Via' value=$data->EnteredVia}
         {dli label='Baseline Rating' value=$data->BaselineRating}
+        {dli label='Growth' value=$data->getGrowth()}
+        {dli label='Progress' value=$data->getProgress()}
         {dli label='Is Level Complete?' value=tif($data->isLevelComplete(), 'Yes', 'No')}
-        {dli label='Growth' value=$data->getGrowth()|number_format:2}
         {dli label='Demonstrations Average' value=$data->getDemonstrationsAverage()|number_format:2}
         {dli label='Demonstrations Logged' value=$data->getDemonstrationsLogged()|number_format}
         {dli label='Demonstrations Missed' value=$data->getDemonstrationsMissed()|number_format}

--- a/php-classes/Slate/CBL/Calculators/Growth/PerformanceLevelMinusBaseline.php
+++ b/php-classes/Slate/CBL/Calculators/Growth/PerformanceLevelMinusBaseline.php
@@ -11,23 +11,68 @@ class PerformanceLevelMinusBaseline implements IGrowthCalculator
         $baseline = $StudentCompetency->getBaselineRating();
         $performanceLevel = $StudentCompetency->getDemonstrationsAverage();
 
+        // try to build dynamic baseline:
+        if ($baseline === null) {
+            $earliestRatings = [];
+            $neededRatings = 0;
+            $demonstrations = $StudentCompetency->getDemonstrationData();
+
+            // find the earliest rating for each skill and count up how many skills have non-zero ER
+            foreach ($StudentCompetency->Competency->getActiveSkills() as $Skill) {
+                // don't count as needed or grab earliest rating if ER==0
+                if (0 === $Skill->getDemonstrationsRequiredByLevel($StudentCompetency->Level)) {
+                    continue;
+                }
+
+                $neededRatings++;
+
+                if (!empty($demonstrations[$Skill->ID])) {
+                    // find the rating with the earliest demonstration date
+                    $earliestTimestamp = null;
+                    $earliestRating = null;
+
+                    foreach ($demonstrations[$Skill->ID] as $skillDemonstration) {
+                        // skip this one if we've already found an earlier one
+                        if ($earliestTimestamp !== null
+                            && $earliestTimestamp < $skillDemonstration['DemonstrationDate']
+                        ) {
+                            continue;
+                        }
+
+                        // skip M ratings
+                        if ($skillDemonstration['DemonstratedLevel'] === 0) {
+                            continue;
+                        }
+
+                        // otherwise, this is our new earliest rating
+                        $earliestRating = $skillDemonstration['DemonstratedLevel'];
+                        $earliestTimestamp = $skillDemonstration['DemonstrationDate'];
+                    }
+
+                    // add this skill's earliest rating to the list, if one was found
+                    if ($earliestRating !== null) {
+                        $earliestRatings[] = $earliestRating;
+                    }
+                }
+            }
+
+            $earliestRatingsCount = count($earliestRatings);
+            if (
+                $earliestRatingsCount > 0
+                && (
+                    $earliestRatingsCount === $neededRatings
+                    || $StudentCompetency->getProgress() >= 0.5
+                )
+            ) {
+                $baseline = array_sum($earliestRatings) / $earliestRatingsCount;
+            }
+        }
+
         // baseline & performance level must > 0
         if (!$performanceLevel || !$baseline) {
             return false;
         }
 
-        // need two ratings, or a rating and baseline to calc growth
-        $skillsWithRatings = 0;
-        foreach ($StudentCompetency->getEffectiveDemonstrationsData() as $skillId => $demonstrations) {
-            if (count($demonstrations) + ($baseline ? 1 : 0) >= 2) {
-                $skillsWithRatings++;
-            }
-        }
-
-        if ($skillsWithRatings === 0) {
-            return false;
-        } else {
-            return $performanceLevel - $baseline;
-        }
+        return $performanceLevel - $baseline;
     }
 }

--- a/php-classes/Slate/CBL/Calculators/Growth/PerformanceLevelMinusBaseline.php
+++ b/php-classes/Slate/CBL/Calculators/Growth/PerformanceLevelMinusBaseline.php
@@ -8,7 +8,7 @@ class PerformanceLevelMinusBaseline implements IGrowthCalculator
 {
     public static function calculateGrowth(StudentCompetency $StudentCompetency)
     {
-        $baseline = $StudentCompetency->getBaselineRating();
+        $baseline = $StudentCompetency->getBaselineAverage();
         $performanceLevel = $StudentCompetency->getDemonstrationsAverage();
 
         // try to build dynamic baseline:

--- a/php-classes/Slate/CBL/Competency.php
+++ b/php-classes/Slate/CBL/Competency.php
@@ -129,6 +129,8 @@ class Competency extends \VersionedRecord
             if ($this->ContentArea) {
                 $this->ContentArea->getActiveSkillIds(true); // true to force refresh of cached value
             }
+
+            Skill::getInactiveIds(true);
         }
 
         if ($wasContentAreaDirty) {

--- a/php-classes/Slate/CBL/ContentArea.php
+++ b/php-classes/Slate/CBL/ContentArea.php
@@ -186,6 +186,8 @@ class ContentArea extends \ActiveRecord
 
     public function save($deep = true)
     {
+        $wasStatusDirty = $this->isFieldDirty('Status');
+
         // set code
         if (!$this->Code) {
             $this->Code = \HandleBehavior::getUniqueHandle($this, $this->Title, [
@@ -195,5 +197,9 @@ class ContentArea extends \ActiveRecord
 
         // call parent
         parent::save($deep);
+
+        if ($wasStatusDirty) {
+            Skill::getInactiveIds(true);
+        }
     }
 }

--- a/php-classes/Slate/CBL/StudentCompetenciesRequestHandler.php
+++ b/php-classes/Slate/CBL/StudentCompetenciesRequestHandler.php
@@ -18,7 +18,7 @@ class StudentCompetenciesRequestHandler extends RecordsRequestHandler
     public static $accountLevelComment = 'Staff';
     public static $accountLevelWrite = 'Administrator';
     public static $browseLimitDefault = 100;
-    public static $browseOrder = ['ID' => 'DESC'];
+    public static $browseOrder = ['Level' => 'DESC', 'ID' => 'DESC'];
 
 
     public static function checkReadAccess(ActiveRecord $Record = null, $suppressLogin = false)

--- a/php-classes/Slate/CBL/StudentCompetency.php
+++ b/php-classes/Slate/CBL/StudentCompetency.php
@@ -121,6 +121,9 @@ class StudentCompetency extends \ActiveRecord
         'progress' => [
             'getter' => 'getProgress'
         ],
+        'baselineAverage' => [
+            'getter' => 'getBaselineAverage'
+        ],
         'next' => [
             'getter' => 'getNext'
         ]
@@ -136,14 +139,14 @@ class StudentCompetency extends \ActiveRecord
             && $this->StudentID && $this->CompetencyID && $this->Level
             && ($Previous = $this->getPrevious())
         ) {
-            $this->BaselineRating = max($Previous->getBaselineRating(), $Previous->getDemonstrationsAverage());
+            $this->BaselineRating = max($Previous->getBaselineAverage(), $Previous->getDemonstrationsAverage());
         }
 
         // call parent
         parent::save($deep);
     }
 
-    public function getBaselineRating()
+    public function getBaselineAverage()
     {
         return $this->BaselineRating !== null ? round($this->BaselineRating, static::$averagePrecision) : null;
     }

--- a/script/test-interactive
+++ b/script/test-interactive
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # script/test-interactive: Run all tests interactively with Cypress GUI
 
@@ -100,4 +100,9 @@ unionfs -o cow \
 
 echo
 echo "==> test-interactive: executing \`cypress open\`…"
-(cd "${temp_path}/merged" && npx cypress open)
+# execute within subshell to isolate env
+(
+    export CYPRESS_REMOTE_DEBUGGING_PORT=9222
+    cd "${temp_path}/merged"
+    npx cypress open
+)

--- a/site-root/powertools/cbl/reset-baselines.php
+++ b/site-root/powertools/cbl/reset-baselines.php
@@ -35,7 +35,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 continue;
             }
 
-            $StudentCompetency->BaselineRating = max($Previous->getBaselineRating(), $Previous->getDemonstrationsAverage());
+            $StudentCompetency->BaselineRating = max($Previous->getBaselineAverage(), $Previous->getDemonstrationsAverage());
             $StudentCompetency->save();
             $updated[] = $StudentCompetency->ID;
         }
@@ -81,8 +81,8 @@ if (!empty($students) && !empty($contentArea)) {
             continue;
         }
 
-        $baseline = $StudentCompetency->getBaselineRating();
-        $previousBaseline = $Previous->getBaselineRating();
+        $baseline = $StudentCompetency->getBaselineAverage();
+        $previousBaseline = $Previous->getBaselineAverage();
         $previousAvg = $Previous->getDemonstrationsAverage();
         $suggestedBaseline = max(
             $previousBaseline,


### PR DESCRIPTION
Continues on work from #663 to further match PLMB growth to spec and resolve disparities with test cases, as well as some supporting work.

- Growth and progress added to browse and details pages for student competencies data:

    <img width="1048" alt="Screen Shot 2022-04-10 at 4 47 48 PM" src="https://user-images.githubusercontent.com/458494/162639129-5becadfd-2755-4773-be6d-de8a4b8e067b.png">

- student competency browsing orders highest levels first by default now, then by ID
- PLMB calculator rewritten to implement spec
- support for attaching VSCode debugger to Cypress tests
- optimized end to end API/CSV/UI tests agains growth/progress test cases
- added cached global method to get list of all inactive skills IDs for efficient filtering
- `student_tasks` tests upgraded for new Cypress APIs and site login command