### PR TITLE
fix: correct text of competency message

### DIFF
--- a/sencha-workspace/SlateDemonstrationsStudent/app/view/NonEnrollmentMessage.js
+++ b/sencha-workspace/SlateDemonstrationsStudent/app/view/NonEnrollmentMessage.js
@@ -3,6 +3,6 @@ Ext.define('SlateDemonstrationsStudent.view.NonEnrollmentMessage', {
     xtype: 'slate-demonstrations-student-nonenrollmentmessage',
     config: {
         cls: 'slate-placeholder',
-        html: 'Not currently enrolled in this competency',
+        html: 'Not currently enrolled in this competency area',
     }
 });


### PR DESCRIPTION
*NOTE* Original issue was resolved by an update to the latest version at that school.  This PR is now just a minor text change requested by Tom in the ticket.

"Not currently enrolled in this competency" is being displayed even when a student is enrolled in al competencies.  Investigate and fix.  Also, add "area" to the end of the message so it read "competency area".

From DD#73