### PR TITLE
refactor(e2e): update remaining e2e tests to newer patterns

### DIFF
--- a/.holo/sources/slate.toml
+++ b/.holo/sources/slate.toml
@@ -1,3 +1,3 @@
 [holosource]
 url = "https://github.com/SlateFoundation/slate"
-ref = "refs/tags/v2.18.12"
+ref = "refs/tags/v2.18.13"

--- a/cypress/integration/cbl/calculations.js
+++ b/cypress/integration/cbl/calculations.js
@@ -156,7 +156,7 @@ describe('CBL: Check UI data against test cases', () => {
             const competencyTestCases = testCases[studentUsername][contentArea];
 
             specify(`${studentUsername} data in ${contentArea} matches test cases`, () => {
-                cy.intercept('/cbl/student-competencies?*').as('getStudentCompetencies');
+                cy.intercept('/cbl/student-competencies?(\\?*)').as('getStudentCompetencies');
                 cy.visit(`/cbl/dashboards/demonstrations/student#${studentUsername}/${contentArea}`);
                 cy.wait('@getStudentCompetencies');
 

--- a/cypress/integration/cbl/competency_dashboard_ratings.js
+++ b/cypress/integration/cbl/competency_dashboard_ratings.js
@@ -7,12 +7,13 @@ describe('CBL: Competency dashboard ratings test', () => {
 
      // authenticate as 'teacher' user
      beforeEach(() => {
-        cy.loginAs('teacher');
-        cy.intercept('GET', '/cbl/content-areas?*').as('getContentAreas');
+        cy.intercept('GET', '/cbl/content-areas?(\\?*)').as('getContentAreas');
         cy.intercept('GET', '/people/\\*student-lists').as('getStudentLists');
-        cy.intercept('GET', '/cbl/student-competencies?*').as('studentCompetencyData');
-        cy.intercept('GET', '/cbl/competencies?*').as('competencyData');
-        cy.intercept('POST', '/cbl/demonstrations/save?*').as('saveDemonstration');
+        cy.intercept('GET', '/cbl/student-competencies?(\\?*)').as('studentCompetencyData');
+        cy.intercept('GET', '/cbl/competencies?(\\?*)').as('competencyData');
+        cy.intercept('POST', '/cbl/demonstrations/save?(\\?*)').as('saveDemonstration');
+
+        cy.loginAs('teacher');
     });
 
     it('Can log a demonstration and verify the UI calculations', () => {
@@ -40,7 +41,7 @@ describe('CBL: Competency dashboard ratings test', () => {
                 .click();
 
             // verify hash updates
-            cy.location('hash').should('eq', '#ELA')
+            cy.location('hash').should('eq', '#ELA');
 
             // click the 'Students' selector
             cy.extGet('slate-cbl-studentslistselector')

--- a/cypress/integration/cbl/student_demonstrations.js
+++ b/cypress/integration/cbl/student_demonstrations.js
@@ -8,6 +8,7 @@ describe('CBL: Student demonstrations test', () => {
     // authenticate as 'student' user
     beforeEach(() => {
         cy.loginAs('student');
+        cy.intercept('GET', '/cbl/content-areas?(\\?*)').as('getContentAreas');
     });
 
     it('View single demonstration rubric as student', () => {
@@ -20,21 +21,21 @@ describe('CBL: Student demonstrations test', () => {
         cy.get('.slate-appcontainer-bodyWrap .slate-placeholder')
             .contains('Select a content area to load demonstrations dashboard');
 
-        cy.withExt().then(({Ext, extQuerySelector, extQuerySelectorAll}) => {
+        // click the 'Rubric' selector
+        cy.extGet('slate-cbl-contentareaselector')
+            .click();
 
-            // get the selector element
-            var contentAreaSelector = extQuerySelector('slate-cbl-contentareaselector');
+        // wait for options to load
+        cy.wait('@getContentAreas');
 
-            // click the selector
-            cy.get('#' + contentAreaSelector.el.dom.id).click();
+        // verify and click first element of picker dropdown
+        cy.extGet('slate-cbl-contentareaselector', { component: true })
+            .then(selector => selector.getPicker().el.dom)
+            .contains('.x-boundlist-item', 'English Language Arts')
+            .click();
 
-            // verify and click first element of picker dropdown
-            cy.get('#' + contentAreaSelector.getPicker().id + ' li:first-child')
-                .contains('English Language Arts')
-                .click();
-
-            // verify content loads
-            cy.get('.slate-demonstrations-student-competenciessummary span').contains('English Language Arts');
-        });
+        // verify content loads
+        cy.get('.slate-demonstrations-student-competenciessummary span')
+            .contains('English Language Arts');
     });
 });

--- a/cypress/integration/cbl/student_tasks.js
+++ b/cypress/integration/cbl/student_tasks.js
@@ -1,154 +1,134 @@
-describe('CBL: Student Tasks test', () => {
-    const dayjs = require('dayjs'),
-        isBetween = require('dayjs/plugin/isBetween');
+const dayjs = require('dayjs');
+const isBetween = require('dayjs/plugin/isBetween');
+const today = dayjs();
 
-    // todo: confirm this is still needed
-    dayjs.extend(isBetween);
+// todo: confirm this is still needed
+dayjs.extend(isBetween);
 
 
-    // load sample database before tests
-    before(() => {
-        cy.resetDatabase();
+// load sample database before tests
+before(() => {
+    cy.resetDatabase();
 
-        // create time relative tasks
-        cy.loginAs('teacher');
+    // create time relative tasks
+    cy.loginAs('teacher');
 
-        // create some relatively due tasks
-        cy.request('POST', `/cbl/tasks/save?format=json`, {
-            data: [{
-                Title: 'Test Task (Due Today)',
-                DueDate: dayjs().format('YYYY-MM--DD'),
-                SectionID: 2,
-                Assignees: {
-                    'student': true
-                }
-            }, {
-                Title: 'Test Task (Due This Week)',
-                DueDate: dayjs().add(5, 'day').format('YYYY-MM--DD'),
-                SectionID: 2,
-                Assignees: {
-                    'student': true
-                }
-            }, {
-                Title: 'Test Task (Due Recently)',
-                DueDate: dayjs().subtract(9, 'day').format('YYYY-MM--DD'),
-                SectionID: 2,
-                Assignees: {
-                    'student': true
-                }
-            }, {
-                Title: 'Test Task (Due Next Week)',
-                DueDate: dayjs().add(8, 'day').format('YYYY-MM--DD'),
-                SectionID: 2,
-                Assignees: {
-                    'student': true
-                }
-            }, {
-                Title: 'Test Task (No Due Date)',
-                SectionID: 2,
-                Assignees: {
-                    'student': true
-                }
-            }, {
-                Title: 'Test Task (Archived)',
-                SectionID: 2,
-                Status: 'archived',
-                Assignees: {
-                    'student': true
-                }
-            }]
-        });
+    // create some relatively due tasks
+    cy.request('POST', `/cbl/tasks/save?format=json`, {
+        data: [{
+            Title: 'Test Task (Due Today)',
+            DueDate: today.format('YYYY-MM--DD'),
+            SectionID: 2,
+            Assignees: {
+                'student': true
+            }
+        }, {
+            Title: 'Test Task (Due This Week)',
+            DueDate: today.add(5, 'day').format('YYYY-MM--DD'),
+            SectionID: 2,
+            Assignees: {
+                'student': true
+            }
+        }, {
+            Title: 'Test Task (Due Recently)',
+            DueDate: today.subtract(9, 'day').format('YYYY-MM--DD'),
+            SectionID: 2,
+            Assignees: {
+                'student': true
+            }
+        }, {
+            Title: 'Test Task (Due Next Week)',
+            DueDate: today.add(8, 'day').format('YYYY-MM--DD'),
+            SectionID: 2,
+            Assignees: {
+                'student': true
+            }
+        }, {
+            Title: 'Test Task (No Due Date)',
+            SectionID: 2,
+            Assignees: {
+                'student': true
+            }
+        }, {
+            Title: 'Test Task (Archived)',
+            SectionID: 2,
+            Status: 'archived',
+            Assignees: {
+                'student': true
+            }
+        }]
     });
+});
 
-    beforeEach(() => {
-        cy.intercept('GET', '/cbl/dashboards/tasks/student/bootstrap?*').as('bootstrapData');
-        cy.intercept('GET', '/cbl/skills?*').as('skillsData');
-        cy.intercept('GET', '/cbl/competencies?*').as('competenciesData');
-        cy.intercept('GET', '/cbl/student-tasks?*').as('studentTasksData');
-        cy.intercept('GET', '/cbl/todos/\\*groups?*').as('studentTodosData');
-        cy.intercept('POST', '/cbl/student-tasks/save?*').as('studentTasksSave');
-    });
+beforeEach(() => {
+    cy.intercept('GET', '/cbl/dashboards/tasks/student/bootstrap?(\\?*)').as('bootstrapData');
+    cy.intercept('GET', '/cbl/skills?(\\?*)').as('skillsData');
+    cy.intercept('GET', '/cbl/competencies?(\\?*)').as('competenciesData');
+    cy.intercept('GET', '/cbl/student-tasks?(\\?*)').as('studentTasksData');
+    cy.intercept('GET', '/cbl/todos/\\*groups?(\\?*)').as('studentTodosData');
+    cy.intercept('POST', '/cbl/student-tasks/save?(\\?*)').as('studentTasksSave');
+});
 
-    const _visitDashboardAsStudent = (student = 'student') => {
-        cy.loginAs(`${student}`);
-        cy.visit(`/cbl/dashboards/tasks/student`);
+function _visitDashboardAsStudent(student = 'student') {
+    cy.loginAs(`${student}`);
+    cy.visit(`/cbl/dashboards/tasks/student`);
 
-        cy.wait('@studentTasksData')
-            .its('response.statusCode')
-            .should('eq', 200);
-    };
-    const _visitDashboardAsTeacher = ({ teacher = 'teacher', student = 'student' } = {}) => {
-        cy.loginAs(`${teacher}`);
-        cy.visit(`/cbl/dashboards/tasks/student#${student}/all`);
+    cy.wait('@studentTasksData')
+        .its('response.statusCode')
+        .should('eq', 200);
+}
 
-        cy.wait('@studentTasksData')
-            .its('response.statusCode')
-            .should('eq', 200);
-    };
+function _visitDashboardAsTeacher({ teacher = 'teacher', student = 'student' } = {}) {
+    cy.loginAs(`${teacher}`);
+    cy.visit(`/cbl/dashboards/tasks/student#${student}/all`);
 
-    const _setupTests = () => {
-        return new Cypress.Promise(resolve => {
+    cy.wait('@studentTasksData')
+        .its('response.statusCode')
+        .should('eq', 200);
+}
 
-            cy.withExt().then(({extQuerySelector}) => {
-                 const currentTasksTree = extQuerySelector('slate-tasks-student-tasktree'),
-                    filterMenu = currentTasksTree.down('slate-tasks-student-taskfiltersmenu'),
-                    _selectFilter = (filterText, filterId = filterMenu.id) => {
-                        return new Cypress.Promise((resolve) => {
-                            cy.get('#' + filterId)
-                                .contains(filterText)
-                                .click({ force: true}) // force click if element isn't visible
-                                .then(() => {
-                                    cy.wait('@studentTasksData')
-                                        .its('response')
-                                        .then(response => {
-                                            expect(response.statusCode).to.equal(200);
+function _selectFilter(filterText, tasksSelector) {
+    cy.extGet('slate-tasks-student-taskfiltersmenu')
+        .contains('.x-menu-item-text', filterText)
+        .click({ force: true}) // force click if element isn't visible
 
-                                            // allow dom re-render
-                                            cy.wait(200).then(() => resolve(response.body));
-                                        })
-                                })
-                        });
+    // wait for XHR response
+    cy.wait('@studentTasksData')
+        .its('response.statusCode')
+        .should('eq', 200);
 
-                    },
-                    _viewAll = () => {
-                        return _selectFilter('View All');
-                    },
-                    _deselectAllFilters = () => {
-                        return new Cypress.Promise(resolve => {
-                            let items = filterMenu.query('menucheckitem[checked]');
-                            items.forEach((i, idx, items) => {
-                                i.setChecked(false);
-                                // if (idx === items.length - 1) {
-                                // }
-                            });
-                            cy.wait('@studentTasksData')
-                                .its('response.statusCode')
-                                .should('eq', 200)
-                                .then(() => resolve(items));
-                        });
-                    },
-                    _clickFilterButton = () => {
-                        return new Cypress.Promise(resolve => {
-                            cy.get('#' + currentTasksTree.id)
-                                .contains('Filter')
-                                .click({ force: true })
-                                .then(tree => resolve(tree));
-                        });
-                    };
-
-                resolve({
-                    _selectFilter,
-                    _viewAll,
-                    _deselectAllFilters,
-                    _clickFilterButton,
-                    currentTasksTree,
-                    filterMenu,
-                });
-            });
+    // wait for filter to be effective
+    cy.extGet('slate-tasks-student-tasktree')
+        .should('not.have.class', 'is-loading')
+        .find('.slate-tasktree-item')
+        .should($tasks => {
+            if (tasksSelector) {
+                const $includedTasks = $tasks.filter(tasksSelector);
+                const $excludedTasks = $tasks.filter(`:not(${tasksSelector})`);
+                expect($includedTasks.length, 'some included items present').to.be.gt(0);
+                expect($excludedTasks.length, 'no excluded items present').to.equal(0);
+            }
         });
-    };
+}
 
-    // Workflow Tests
+function _deselectAllFilters() {
+    cy.extGet('slate-tasks-student-taskfiltersmenu menucheckitem[checked]', { component: true, all: true })
+        .each(item => item.setChecked(false))
+
+    cy.wait('@studentTasksData')
+        .its('response.statusCode')
+        .should('eq', 200);
+}
+
+function _clickFilterButton() {
+    cy.extGet('slate-tasks-student-tasktree')
+        .contains('.x-btn-inner', 'Filter')
+        .click({ force: true });
+};
+
+
+describe('CBL: Student Tasks Workflows', () => {
+
     it('Submit task as student / Re-Assign As Teacher', () => {
         // todo: create task in test? we want to make sure tests don't fail because of previous test failures or successes
         let studentUsername = 'student',
@@ -158,7 +138,7 @@ describe('CBL: Student Tasks test', () => {
         cy.request('POST', `/cbl/tasks/save?format=json`, {
             data: [{
                 Title: 'Test Task (Revision Workflow)',
-                DueDate: dayjs().format('YYYY-MM--DD'),
+                DueDate: today.format('YYYY-MM--DD'),
                 SectionID: 2,
                 Assignees: {
                     'student': true
@@ -167,120 +147,181 @@ describe('CBL: Student Tasks test', () => {
         });
 
         _visitDashboardAsStudent(studentUsername);
-        _setupTests().then(({ _clickFilterButton, _selectFilter, _deselectAllFilters, currentTasksTree }) => {
-            return _clickFilterButton()
-                .then(_deselectAllFilters)
-                .then(() => _selectFilter('Due'))
-                .then(() => {
-                    cy.wait(2000) // wait for dom to re-render
-                        .then(() => {
-                            cy.get('#' + currentTasksTree.id)
-                                .contains('Revision Workflow')
-                                .click({ force: true })
-                                // .find('li.slate-tasktree-item')
-                                // .then((found) => {
-                                //     cy.get(found.first())
-                                //         .scrollIntoView()
-                                //         .click();
-                                // })
-                            cy.wait(['@skillsData', '@competenciesData'])
-                                .should(intercepts => {
-                                    for (const { response } of intercepts) {
-                                        expect(response.statusCode).to.equal(200);
-                                        expect(response.body.success).to.be.true;
-                                    }
-                                });
+        _clickFilterButton();
+        _deselectAllFilters();
+        _selectFilter('Due Tasks', '.slate-tasktree-status-due, .slate-tasktree-status-late');
 
-                            cy.get('.slate-window')
-                                .contains('Submit Assignment')
-                                .should((btn) => {
-                                    expect(btn).to.be.visible;
-                                    expect(btn.attr('aria-disabled')).to.not.be.true;
-                                })
-                                .click({ force: true })
+        cy.extGet('slate-tasks-student-tasktree')
+            .contains('.slate-tasktree-title', 'Revision Workflow')
+            .click({ force: true });
 
-                            cy.wait('@studentTasksSave')
-                                .should(({ response }) => {
-                                    expect(response.statusCode).to.equal(200);
-                                    expect(response.body.success).to.be.true;
-                                });
-
-                            cy.get('#' + currentTasksTree.id)
-                                .contains('Submitted');
-
-                        });
-                })
-        }).then(() => {
-            // re-assign as teacher
-            _visitDashboardAsTeacher({
-                student: studentUsername,
-                teacher: teacherUsername,
-            })
-            _setupTests().then(({ _clickFilterButton, _deselectAllFilters, _selectFilter, currentTasksTree }) => {
-                cy.get('.slate-appcontainer')
-                    .should('be.visible');
-
-                _clickFilterButton()
-                    .then(_deselectAllFilters)
-                    .then(() => _selectFilter('Submitted'))
-                    .then(() => {
-                        cy.get('#' + currentTasksTree.getId())
-                            .contains('Revision Workflow')
-                            .click({ force: true })
-
-                        cy.wait('@studentTasksData')
-                            .its('response.statusCode')
-                            .should('eq', 200);
-
-                        cy.get('.slate-window')
-                            .contains('label', 'Re-assign')
-                            .click();
-
-                        cy.get('.slate-window')
-                            .contains('Save Assignment')
-                            .should((btn) => {
-                                expect(btn).to.be.visible;
-                                expect(btn.attr('aria-disabled')).to.not.be.true;
-                            })
-                            .click();
-
-                        cy.wait('@studentTasksSave')
-                            .should(({ response }) => {
-                                expect(response.statusCode).to.equal(200);
-                                expect(response.body.success).to.be.true;
-                            });
-
-                        cy.get('#' + currentTasksTree.id)
-                            .contains('.slate-tasktree-status', 'Revision');
-                    })
-
-
+        cy.wait(['@skillsData', '@competenciesData'])
+            .should(intercepts => {
+                for (const { response } of intercepts) {
+                    expect(response.statusCode).to.equal(200);
+                    expect(response.body.success).to.be.true;
+                }
             });
-        })
+
+        cy.extGet('slate-window')
+            .contains('.x-btn-inner', 'Submit Assignment')
+            .should((btn) => {
+                expect(btn).to.be.visible;
+                expect(btn.attr('aria-disabled')).to.not.be.true;
+            })
+            .click();
+
+        cy.wait('@studentTasksSave')
+            .should(({ response }) => {
+                expect(response.statusCode).to.equal(200);
+                expect(response.body.success).to.be.true;
+            });
+
+        cy.extGet('slate-tasks-student-tasktree')
+            .contains('Submitted');
+
+
+        // re-assign as teacher
+        _visitDashboardAsTeacher({
+            student: studentUsername,
+            teacher: teacherUsername,
+        });
+
+        _clickFilterButton();
+        _deselectAllFilters();
+        _selectFilter('Submitted', '.slate-tasktree-status-due.needsrated');
+
+        cy.extGet('slate-tasks-student-tasktree')
+            .contains('.slate-tasktree-title', 'Revision Workflow')
+            .click();
+
+        cy.wait('@studentTasksData')
+            .its('response.statusCode')
+            .should('eq', 200);
+
+        cy.extGet('slate-window')
+            .contains('.x-form-cb-label', 'Re-assign')
+            .click();
+
+        cy.extGet('slate-window')
+            .contains('.x-btn-inner', 'Save Assignment')
+            .should((btn) => {
+                expect(btn).to.be.visible;
+                expect(btn.attr('aria-disabled')).to.not.be.true;
+            })
+            .click();
+
+        cy.wait('@studentTasksSave')
+            .should(({ response }) => {
+                expect(response.statusCode).to.equal(200);
+                expect(response.body.success).to.be.true;
+            });
+
+        cy.extGet('slate-tasks-student-tasktree')
+            .contains('.slate-tasktree-status', 'Revision')
+            .should('exist');
     });
 
-    // Section Filters
+    it('Submitted Tasks Filter', () => {
+        // create the task as teacher and assign to student
+        _visitDashboardAsTeacher();
+        cy.request('POST', `/cbl/tasks/save?format=json&include=StudentTasks`, {
+            data: [{
+                Title: 'Test Task (Submitted)',
+                DueDate: today.format('YYYY-MM--DD'),
+                SectionID: 2,
+                Assignees: {
+                    student: true
+                }
+            }]
+        }).then(response => {
+            expect(response.body.data).to.be.an('array').and.to.have.length(1);
+            expect(response.body.data[0].StudentTasks).to.be.an('array').and.to.have.length(1);
+            const studentTaskId = response.body.data[0].StudentTasks[0].ID;
+
+            // login as student, and submit
+            _visitDashboardAsStudent();
+            _clickFilterButton();
+            _deselectAllFilters();
+            _selectFilter('Due Tasks', '.slate-tasktree-status-due, .slate-tasktree-status-late');
+
+            // open recently created task
+            cy.extGet('slate-tasks-student-tasktree')
+                .find(`.slate-tasktree-item[data-id=${studentTaskId}]`)
+                .should('have.length', 1)
+                .click();
+
+            cy.wait(['@skillsData', '@competenciesData'])
+                .should(intercepts => {
+                    for (const { response } of intercepts) {
+                        expect(response.statusCode).to.equal(200);
+                        expect(response.body.success).to.be.true;
+                    }
+                });
+
+            // submit task as student
+            cy.extGet('slate-window')
+                .contains('.x-btn-inner', 'Submit Assignment')
+                .should((btn) => {
+                    expect(btn).to.be.visible;
+                    expect(btn.attr('aria-disabled')).to.not.be.true;
+                })
+                .click();
+
+            cy.wait('@studentTasksSave')
+                .should(({ response }) => {
+                    expect(response.statusCode).to.equal(200);
+                    expect(response.body.success).to.be.true;
+                    expect(response.body.data).to.be.an('array').and.to.have.length(1);
+                    expect(response.body.data[0].ID).to.equal(studentTaskId);
+                });
+
+            // verify status shows as submitted to student
+            cy.extGet('slate-tasks-student-tasktree')
+                .find(`.slate-tasktree-item[data-id=${studentTaskId}]`)
+                .should('have.length', 1)
+                .should('have.class', 'needsrated')
+                .contains('.slate-tasktree-status', 'Submitted');
+
+            // switch to teacher view
+            _visitDashboardAsTeacher();
+            _clickFilterButton();
+            _deselectAllFilters();
+            _selectFilter('Submitted', '.slate-tasktree-status-due.needsrated');
+
+            // verify status shows as submitted to student
+            cy.extGet('slate-tasks-student-tasktree')
+                .find(`.slate-tasktree-item[data-id=${studentTaskId}]`)
+                .should('have.length', 1)
+                .should('have.class', 'needsrated')
+                .contains('.slate-tasktree-status', 'Submitted');
+        });
+    });
+});
+
+
+describe('CBL: Student Tasks Section Filters', () => {
+
     // todo: ensure we create data that should NOT included in filter
     it('Enrolled Sections Filter', () => {
         let studentUsername = 'student';
         _visitDashboardAsTeacher({ student: studentUsername });
-        _setupTests()
-            .then(({ _deselectAllFilters, _selectFilter, _clickFilterButton }) => {
-                _clickFilterButton()
-                    .then(_deselectAllFilters)
-                    .then(() => _selectFilter('Enrolled Sections'))
-                    .then(({ data: studentTasks }) => {
-                        // get the users sections ids from the current term via the API
-                        cy.request(`/sections?enrolled_user=${studentUsername}&format=json`).as('currentSections');
-                        cy.get('@currentSections').then((response) => {
-                            const { data: sections } = response.body,
-                                sectionIds = sections.map(section => section.ID);
-                            // confirm that all student tasks loaded are in the list we got from the API
-                            studentTasks.forEach(studentTask => {
-                                expect(studentTask.Task.SectionID, 'Section ID within enrolled section IDs').to.be.oneOf(sectionIds);
-                            });
-                        });
-                })
+        _clickFilterButton();
+        _deselectAllFilters();
+        _selectFilter('Enrolled Sections');
+
+        // get the users sections ids from the current term via the API
+        cy.request(`/sections?enrolled_user=${studentUsername}&format=json`)
+            .then(response => {
+                const { data: sections } = response.body;
+                const sectionIds = sections.map(section => section.ID);
+
+                // confirm that all student tasks loaded are in the list we got from the API
+                cy.get('@studentTasksData').then(({ response }) => {
+                    for (const studentTask of response.body.data) {
+                        expect(studentTask.Task.SectionID, 'Section ID within enrolled section IDs').to.be.oneOf(sectionIds);
+                    }
+                });
             });
     });
 
@@ -288,335 +329,174 @@ describe('CBL: Student Tasks test', () => {
     it('Currently Term, Enrolled Sections Filter', () => {
         let studentUsername = 'student';
         _visitDashboardAsTeacher({ student: studentUsername });
-        _setupTests()
-            .then(({ _deselectAllFilters, _selectFilter, _clickFilterButton }) => {
-                _clickFilterButton()
-                    .then(_deselectAllFilters)
-                    .then(() => _selectFilter('Current Term'))
-                    .then(() => _selectFilter('Enrolled Section'))
-                    .then(({ data: studentTasks }) => {
-                        // get the users sections ids from the current term via the API
-                        cy.request(`/sections?term=*current&enrolled_user=${studentUsername}&format=json`).as('currentSections');
-                        cy.get('@currentSections').then((response) => {
-                            const { data: sections } = response.body;
-                            const sectionIds = sections.map(section => section.ID);
+        _clickFilterButton();
+        _deselectAllFilters();
+        _selectFilter('Current Term');
+        _selectFilter('Enrolled Section');
 
-                            // confirm that all student tasks loaded are in the list we got from the API
-                            studentTasks.forEach(studentTask => {
-                                expect(studentTask.Task.SectionID).to.be.oneOf(sectionIds);
-                            });
-                        });
+        // get the users sections ids from the current term via the API
+        cy.request(`/sections?term=*current&enrolled_user=${studentUsername}&format=json`)
+            .then(response => {
+                const { data: sections } = response.body;
+                const sectionIds = sections.map(section => section.ID);
 
-                })
+                // confirm that all student tasks loaded are in the list we got from the API
+                cy.get('@studentTasksData').then(({ response }) => {
+                    for (const studentTask of response.body.data) {
+                        expect(studentTask.Task.SectionID, 'Section ID within enrolled section IDs').to.be.oneOf(sectionIds);
+                    }
+                });
             });
     });
+});
 
-    // Status Filters
+
+describe('CBL: Student Tasks Status Filters', () => {
+
     // todo: ensure we create data that should NOT included in filter
     it('Archived Tasks Filter', () => {
         _visitDashboardAsTeacher();
-        _setupTests()
-            .then(({ _deselectAllFilters, _selectFilter, _clickFilterButton }) => {
-                _clickFilterButton()
-                    .then(_deselectAllFilters)
-                    .then(() => _selectFilter('Archived Task'))
-                    .then(({ data }) => {
-                        // expect there to be at least 1 archived task that was created in the 'before' method
-                        expect(data.map(studentTask => studentTask.Task.Status.toLowerCase() === 'archived').length).to.be.greaterThan(0);
-                    })
-            })
+        _clickFilterButton();
+        _deselectAllFilters();
+        _selectFilter('Archived Task');
+
+        cy.get('@studentTasksData').then(({ response }) => {
+            const archived = response.body.data.filter(studentTask => studentTask.Task.Status.toLowerCase() === 'archived');
+            expect(archived.length, 'at least one archived task included').to.be.greaterThan(0);
+        });
     });
 
     // todo: ensure we create data that should NOT included in filter
     it('Revision Tasks Filter', () => {
         _visitDashboardAsTeacher();
-        _setupTests()
-            .then(({ _deselectAllFilters, _selectFilter, _clickFilterButton, currentTasksTree }) => {
-                _clickFilterButton()
-                    .then(_deselectAllFilters)
-                    .then(() => _selectFilter('Revision Tasks'))
-                    .then(() => {
-                        // expect there to be at least 1 archived task that was created in the 'before' method
-                        cy.wait(1000); // allow dom re-render
-
-                        cy.get('#' + currentTasksTree.getId())
-                            .find('ul.slate-tasktree-list')
-                            .children('li.slate-tasktree-item')
-                            .each(($item) => {
-                                cy.get($item).find('.slate-tasktree-status').contains('Revision');
-                            });
-                    })
-            })
+        _clickFilterButton();
+        _deselectAllFilters();
+        _selectFilter('Revision Tasks', '.slate-tasktree-status-revision');
     });
 
     // todo: ensure we create data that should NOT included in filter
     it('Due Tasks Filter', () => {
         _visitDashboardAsTeacher();
-        _setupTests()
-            .then(({ _deselectAllFilters, _selectFilter, _clickFilterButton, currentTasksTree }) => {
-                _clickFilterButton()
-                    .then(_deselectAllFilters)
-                    .then(() => _selectFilter('Due Tasks'))
-                    .then(() => {
-                        // expect there to be at least 1 archived task that was created in the 'before' method
-                        // expect(response.body.data.map(studentTask => studentTask.Task.Status.toLowerCase() === 'archived').length).to.be.greaterThan(0);
-
-                        cy.get('#' + currentTasksTree.getId())
-                            .find('ul.slate-tasktree-list')
-                            .children('li.slate-tasktree-item')
-                            .each(($item) => {
-                                cy.get($item).find('.slate-tasktree-status').contains('Due'); // confirm the status text exists
-                            });
-                    })
-            })
+        _clickFilterButton();
+        _deselectAllFilters();
+        _selectFilter('Due Tasks', '.slate-tasktree-status-due, .slate-tasktree-status-late');
     });
+});
 
-    // Timeline Filters
+
+describe('CBL: Student Tasks Timeline Filters', () => {
+
     // todo: ensure we create data that should NOT included in filter
     it('Past Due Filter', () => {
         _visitDashboardAsTeacher();
-        _setupTests().then(({ _deselectAllFilters, _selectFilter, _clickFilterButton, currentTasksTree }) => {
-            _clickFilterButton()
-                .then(_deselectAllFilters)
-                .then(() => _selectFilter('Past Due'))
-                .then(() => {
-                    cy.get('#' + currentTasksTree.getId())
-                        .find('ul.slate-tasktree-list')
-                        .children('li.slate-tasktree-item')
-                        .each(($item) => {
-                            cy.get($item).find('.slate-tasktree-date').should( $date => {
+        _clickFilterButton();
+        _deselectAllFilters();
+        _selectFilter('Past Due', '.slate-tasktree-status-late');
 
-                                let today = dayjs(),
-                                    date = dayjs($date.text()),
-                                    isAfter = today.isAfter(date, 'day') || today.isSame(date, 'day');
-
-                                // if (!isAfter) {
-                                //     debugger;
-                                // }
-
-                                console.log({
-                                    today,
-                                    date,
-                                    isAfter,
-                                    $date,
-                                });
-                                expect(isAfter, 'Due date is before current date').to.equal(true);
-                            })
-                        })
-                })
-        })
+        // check due dates of remaining tasks
+        cy.extGet('slate-tasks-student-tasktree')
+            .find('.slate-tasktree-item')
+            .each($task => {
+                const date = dayjs($task.find('.slate-tasktree-date').text(), 'MMM, DD YYYY');
+                const isAfter = today.isAfter(date, 'day') || today.isSame(date, 'day');
+                expect(isAfter, 'Due date is before current date').to.equal(true);
+            });
     });
 
-    it('Submitted Tasks Filter', () => {
-        const taskTitle = 'Test Task (Submitted)';
-        // create the task as teacher and assign to student
+    it('Completed Tasks Filter', () => {
         _visitDashboardAsTeacher();
-        cy.request('POST', `/cbl/tasks/save?format=json`, {
-            data: [{
-                Title: taskTitle,
-                DueDate: dayjs().format('YYYY-MM--DD'),
-                SectionID: 2,
-                Assignees: {
-                    'student': true
-                }
-            }]
-        });
-
-        // login as student, and submit
-        _visitDashboardAsStudent();
-        _setupTests().then(({ _clickFilterButton, _selectFilter, _deselectAllFilters, currentTasksTree }) => {
-            return _clickFilterButton()
-                .then(_deselectAllFilters)
-                .then(() => _selectFilter('Due'))
-                .then(() => {
-                    cy.wait(2000) // wait for dom to re-render
-                        .then(() => {
-                            cy.get('#' + currentTasksTree.id)
-                                .contains(taskTitle)
-                                .click({ force: true })
-
-                            cy.wait(['@skillsData', '@competenciesData'])
-                                .should(intercepts => {
-                                    for (const { response } of intercepts) {
-                                        expect(response.statusCode).to.equal(200);
-                                        expect(response.body.success).to.be.true;
-                                    }
-                                });
-
-                            cy.get('.slate-window')
-                                .contains('Submit Assignment')
-                                .should((btn) => {
-                                    expect(btn).to.be.visible;
-                                    expect(btn.attr('aria-disabled')).to.not.be.true;
-                                })
-                                .click({ force: true })
-
-                            cy.wait('@studentTasksSave')
-                                .should(({ response }) => {
-                                    expect(response.statusCode).to.equal(200);
-                                    expect(response.body.success).to.be.true;
-                                });
-
-                            cy.get('#' + currentTasksTree.id)
-                                .contains('Submitted');
-
-                        });
-                })
-        })
-        .then(() => {
-            _visitDashboardAsTeacher();
-            _setupTests()
-                .then(({ _deselectAllFilters, _selectFilter, _clickFilterButton, currentTasksTree }) => {
-                    _clickFilterButton()
-                    .then(_deselectAllFilters)
-                    .then(() => _selectFilter('Submitted Tasks'))
-                    .then(() => {
-                        cy.get('#' + currentTasksTree.id)
-                            .find('ul.slate-tasktree-list')
-                            .children('li.slate-tasktree-item')
-                            .each(($item) => {
-                                cy.get($item).find('.slate-tasktree-status').contains('Submitted'); // confirm the status text exists
-                            });
-                    })
-                })
-        })
+        _clickFilterButton();
+        _deselectAllFilters();
+        _selectFilter('Completed Tasks', '.slate-tasktree-status-completed');
     });
 
-    it('Completed Tasks Filter', ()=>{
+    it('Due Today Tasks Filter', () => {
         _visitDashboardAsTeacher();
-        _setupTests()
-        .then(({ _deselectAllFilters, _selectFilter, _clickFilterButton, currentTasksTree }) => {
-            _clickFilterButton()
-            .then(_deselectAllFilters)
-            .then(() => _selectFilter('Completed Tasks'))
-            .then(() => {
-                cy.wait(500); // allow dom re-render
-                cy.get('#' + currentTasksTree.id)
-                    .find('ul.slate-tasktree-list')
-                    .children('li.slate-tasktree-item')
-                    .each(($item) => {
-                        cy.get($item).find('.slate-tasktree-status').contains('Completed'); // confirm the status text exists
-                    });
-            })
-        })
-    })
+        _clickFilterButton();
+        _deselectAllFilters();
+        _selectFilter('Due Today', '.slate-tasktree-status-due, .slate-tasktree-status-revision');
 
-    it('Due Today Tasks Filter', ()=>{
+        // check due dates of remaining tasks
+        cy.extGet('slate-tasks-student-tasktree')
+            .find('.slate-tasktree-item')
+            .each($task => {
+                const date = dayjs($task.find('.slate-tasktree-date').text(), 'MMM, DD YYYY');
+                const dueToday = today.isSame(date, 'day');
+                expect(dueToday, 'Due date is same as current date').to.equal(true);
+            });
+    });
+
+    it('Due This Week Tasks Filter', () => {
         _visitDashboardAsTeacher();
-        _setupTests()
-        .then(({ _deselectAllFilters, _selectFilter, _clickFilterButton, currentTasksTree }) => {
-            _clickFilterButton()
-            .then(_deselectAllFilters)
-            .then(() => _selectFilter('Due Today'))
-            .then(() => {
-                cy.get('#' + currentTasksTree.id)
-                    .find('ul.slate-tasktree-list')
-                    .children('li.slate-tasktree-item')
-                    .each(($item) => {
-                        cy.get($item).find('.slate-tasktree-date').should( $date => {
-                            let today = dayjs(),
-                                date = dayjs($date.text(), 'MMM, DD YYYY'),
-                                dueToday = today.isSame(date, 'day');
+        _clickFilterButton();
+        _deselectAllFilters();
+        _selectFilter('Due This Week', '.slate-tasktree-status-due, .slate-tasktree-status-revision');
 
-                            expect(dueToday, 'Due date is same as current date').to.equal(true);
-                        })
-                    });
-            })
-        })
-    })
+        // check due dates of remaining tasks
+        const startOfNextWeek = today.add(8, 'day');
+        const yesterday = today.subtract(1, 'day');
 
-    it('Due This Week Tasks Filter', ()=>{
+        cy.extGet('slate-tasks-student-tasktree')
+            .find('.slate-tasktree-item')
+            .each($task => {
+                const date = dayjs($task.find('.slate-tasktree-date').text(), 'MMM, DD YYYY');
+                const dateIsBetween = date.isBetween(yesterday, startOfNextWeek);
+                expect(dateIsBetween, 'Due date between yesterday and next week').to.be.true;
+            });
+    });
+
+    it('Due Next Week Tasks Filter', () => {
         _visitDashboardAsTeacher();
-        _setupTests()
-        .then(({ _deselectAllFilters, _selectFilter, _clickFilterButton, currentTasksTree }) => {
-            _clickFilterButton()
-            .then(_deselectAllFilters)
-            .then(() => _selectFilter('Due This Week'))
-            .then(() => {
-                cy.get('#' + currentTasksTree.id)
-                    .find('ul.slate-tasktree-list')
-                    .children('li.slate-tasktree-item')
-                    .each(($item) => {
-                        cy.get($item).find('.slate-tasktree-date').should( $date => {
-                              const date = dayjs($date.text(), 'MMM, DD YYYY'),
-                                 inOneWeek = dayjs().add(8, 'day').format('MMM, DD YYYY'),
-                                 yesterday = dayjs().subtract(1, 'day').format('MMM, DD YYYY'),
-                                 dateIsBetween = dayjs(date).isBetween(yesterday, dayjs(inOneWeek));
+        _clickFilterButton();
+        _deselectAllFilters();
+        _selectFilter('Due Next Week', '.slate-tasktree-status-due, .slate-tasktree-status-revision');
 
-                                 expect(dateIsBetween).to.be.true;
-                        })
-                    });
-            })
-        })
-    })
+        // check due dates of remaining tasks
+        const endOfThisWeek = today.add(7, 'day');
 
-    it('Due Next Week Tasks Filter', ()=>{
+        cy.extGet('slate-tasks-student-tasktree')
+            .find('.slate-tasktree-item')
+            .each($task => {
+                const date = dayjs($task.find('.slate-tasktree-date').text(), 'MMM, DD YYYY');
+                const isAfter = date.isAfter(endOfThisWeek);
+                expect(isAfter, 'Due date after this week').to.be.true;
+            });
+    });
+
+    it('Due Recently Upcoming Tasks Filter', () => {
         _visitDashboardAsTeacher();
-        _setupTests()
-        .then(({ _deselectAllFilters, _selectFilter, _clickFilterButton, currentTasksTree }) => {
-            _clickFilterButton()
-            .then(_deselectAllFilters)
-            .then(() => _selectFilter('Due Next Week'))
-            .then(() => {
-                cy.get('#' + currentTasksTree.id)
-                    .find('ul.slate-tasktree-list')
-                    .children('li.slate-tasktree-item')
-                    .each(($item) => {
-                        cy.get($item).find('.slate-tasktree-date').should( $date => {
-                              const date = dayjs($date.text(), 'MMM, DD YYYY'),
-                                inOneWeek = dayjs().add(7, 'day').format('MMM, DD YYYY'),
-                                isAfter = dayjs(date).isAfter(inOneWeek);
-                                console.log({date, inOneWeek, isAfter})
+        _clickFilterButton();
+        _deselectAllFilters();
+        _selectFilter('Due (recently/upcoming)', '.slate-tasktree-status-due, .slate-tasktree-status-revision, .slate-tasktree-status-late');
 
-                                 expect(isAfter).to.be.true;
-                        })
-                    });
-            })
-        })
-    })
+        // check due dates of remaining tasks
+        const tenDaysAgo = today.subtract(10, 'day');
+        const tenDaysFromNow = today.add(10, 'day');
 
-    it('Due Recently Upcoming Tasks Filter', ()=>{
+        cy.extGet('slate-tasks-student-tasktree')
+            .find('.slate-tasktree-item')
+            .each($task => {
+                const date = dayjs($task.find('.slate-tasktree-date').text(), 'MMM, DD YYYY');
+                const isBetween = date.isBetween(tenDaysAgo, tenDaysFromNow);
+                expect(isBetween, 'Due date between 10 day ago and 10 days from now').to.be.true;
+            });
+    });
+
+    it('Due Tasks (no date) Filter', () => {
         _visitDashboardAsTeacher();
-        _setupTests()
-        .then(({ _deselectAllFilters, _selectFilter, _clickFilterButton, currentTasksTree }) => {
-            _clickFilterButton()
-            .then(_deselectAllFilters)
-            .then(() => _selectFilter('Due Next Week'))
-            .then(() => {
-                cy.get('#' + currentTasksTree.id)
-                    .find('ul.slate-tasktree-list')
-                    .children('li.slate-tasktree-item')
-                    .each(($item) => {
-                        cy.get($item).find('.slate-tasktree-date').should( $date => {
-                              const date = dayjs($date.text(), 'MMM, DD YYYY'),
-                               lastTenDays = dayjs().subtract(10, 'day').format('MMM, DD YYYY'),
-                               nextTenDays = dayjs().add(10, 'day').format('MMM, DD YYYY'),
-                               dateIsBetween = dayjs(date).isBetween(lastTenDays, dayjs(nextTenDays));
+        _clickFilterButton();
+        _deselectAllFilters();
+        _selectFilter('Due (no date)');
 
-                              expect(dateIsBetween).to.be.true;
-                        })
-                    });
-            })
-        })
-    })
-
-    it('Due Tasks (no date) Filter', ()=>{
-        _visitDashboardAsTeacher();
-        _setupTests()
-        .then(({ _deselectAllFilters, _selectFilter, _clickFilterButton, currentTasksTree }) => {
-            _clickFilterButton()
-            .then(_deselectAllFilters)
-            .then(() => _selectFilter('Due (no date)'))
-            .then(() => {
-                cy.get('#' + currentTasksTree.id)
-                    .find('ul.slate-tasktree-list')
-                    .children('li.slate-tasktree-item')
-                    .each(($item) => {
-                        cy.get($item).find('.slate-tasktree-date').should( $date => {
-                            expect($date.text(), 'The date should be empty').to.be.empty;
-                        })
-                    });
-            })
-        })
-    })
+        // wait for filter to be effective
+        cy.extGet('slate-tasks-student-tasktree')
+            .should('not.have.class', 'is-loading')
+            .find('.slate-tasktree-item')
+            .should($tasks => {
+                const $includedTasks = $tasks.find('.slate-tasktree-date:empty');
+                const $excludedTasks = $tasks.find('.slate-tasktree-date:not(:empty)');
+                expect($includedTasks.length, 'some included items present').to.be.gt(0);
+                expect($excludedTasks.length, 'no excluded items present').to.equal(0);
+            });
+    });
 });

--- a/cypress/integration/cbl/student_tasks_competency_rating.js
+++ b/cypress/integration/cbl/student_tasks_competency_rating.js
@@ -18,20 +18,16 @@ describe('CBL: Student tasks demonstrations competency rating level test', () =>
         // wait for grid container to load
         cy.get('.slate-appcontainer').contains('ELA Task One');
 
-        cy.withExt().then(({Ext, extQuerySelector, extQuerySelectorAll}) => {
+        // find and click the first grid cell
+        cy.extGet('slate-studentsgrid')
+            .should('exist')
+            .find('.slate-studentsgrid-cell')
+            .first()
+            .click();
 
-            // find teh student's grid
-            var studentsGrid = extQuerySelector('slate-studentsgrid');
-
-            // find and click the first grid cell
-            cy.get('#' + studentsGrid.el.dom.id + ' .slate-studentsgrid-cell')
-                .first()
-                .click();
-
-            // ensure the first skill rating field has class 'cbl-level-9'
-            cy.get('.slate-cbl-skillratingsfield .slate-cbl-ratings-slider')
-                .first()
-                .should('have.have.class', 'cbl-level-9')
-        });
+        // ensure the first skill rating field has class 'cbl-level-9'
+        cy.get('.slate-cbl-skillratingsfield .slate-cbl-ratings-slider')
+            .first()
+            .should('have.have.class', 'cbl-level-9')
     });
 });

--- a/cypress/integration/cbl/tasks_manager.js
+++ b/cypress/integration/cbl/tasks_manager.js
@@ -2,13 +2,14 @@ describe('CBL: Tasks Manager Test', () => {
 
     // load sample database before tests
     before(() => {
-        // cy.resetDatabase();
+        cy.resetDatabase();
     });
 
     // authenticate as 'teacher' user
     beforeEach(() => {
-        cy.intercept('GET', '/cbl/tasks?(\\?*)').as('taskData');
+        cy.intercept('GET', '/cbl/tasks?(\\?*)').as('tasksData');
         cy.intercept('POST', '/cbl/tasks/save?(\\?*)').as('taskSave');
+        cy.intercept('POST', '/cbl/tasks/destroy?(\\?*)').as('taskDestroy');
 
         cy.loginAs('teacher');
     });
@@ -18,47 +19,39 @@ describe('CBL: Tasks Manager Test', () => {
         // open student demonstrations dashboard
         cy.visit('/cbl/dashboards/tasks/manager');
 
-        // verify teacher redirect
-        cy.location('hash').should('eq', '');
-
+        // verify app loaded
         cy.get('#slateapp-viewport')
-            .contains('Task Library');
+            .contains('.slate-appheader-title', 'Task Library');
 
-        cy.withExt().then(({Ext, extQuerySelector, extQuerySelectorAll}) => {
+        // wait for data load
+        cy.wait('@tasksData');
 
-            // get the selector element
-            var taskManager = extQuerySelector('slate-tasks-manager'),
-                appHeader = taskManager.down('slate-tasks-manager-appheader'),
-                createBtn = appHeader.down('button[action=create]');
-                // editBtn = appHeader.down('button[action=edit]'),
-                // deleteBtn = appHeader.down('button[action=delete]');
+        // click create button
+        cy.extGet('slate-tasks-manager-appheader button[action=create]')
+            .click();
 
+        // wait for window to transition open
+        cy.extGet('slate-window')
+            .should('not.have.class', 'x-hidden-clip')
+            .within(() => {
+                cy.root()
+                    .contains('.x-title-text', 'Create Task');
 
-            // click create button
-            cy.get('#' + createBtn.getId())
-                .click({ force: true });
+                cy.root()
+                    .contains('.x-form-item-label-text', 'Title')
+                    .click();
 
-            cy.wait("@taskData")
-            cy.get('@taskData.all').should('have.length', 1)
+                cy.focused()
+                    .should('have.attr', 'name', 'Title')
+                    .type('Created Test Task Title');
 
-            cy.get('.slate-window')
-                .contains('Create Task');
+                cy.get('.slate-panelfooter')
+                    .contains('.x-btn-inner', 'Create')
+                    .click();
+            });
 
-            cy.get('.slate-window')
-                .contains('Title')
-                .click({ force: true })
-
-            cy.focused()
-                .should('have.attr', 'name', 'Title')
-                .type('Test Task Title');
-
-            cy.get('.slate-window .slate-panelfooter')
-                .contains('Create')
-                .click({ force: true });
-
-            cy.wait("@taskSave")
-            cy.get('@taskSave.all').should('have.length', 1)
-        });
+        // wait for data save
+        cy.wait('@taskSave');
     });
 
     it('Edit public task as teacher', () => {
@@ -66,94 +59,100 @@ describe('CBL: Tasks Manager Test', () => {
         // open student demonstrations dashboard
         cy.visit('/cbl/dashboards/tasks/manager');
 
-        // verify teacher redirect
-        cy.location('hash').should('eq', '');
-
+        // verify app loaded
         cy.get('#slateapp-viewport')
-            .contains('Task Library');
+            .contains('.slate-appheader-title', 'Task Library');
 
-        cy.withExt().then(({Ext, extQuerySelector, extQuerySelectorAll}) => {
+        // wait for data load
+        cy.wait('@tasksData');
 
-            // get the selector element
-            var taskManager = extQuerySelector('slate-tasks-manager'),
-                appHeader = taskManager.down('slate-tasks-manager-appheader'),
-                editBtn = appHeader.down('button[action=edit]');
-                // deleteBtn = appHeader.down('button[action=delete]');
+        // find and click created task
+        cy.extGet('slate-tasks-manager')
+            .contains('.x-grid-cell-inner', 'Created Test Task Title')
+            .click();
 
+        // click edit button
+        cy.extGet('slate-tasks-manager-appheader button[action=edit]')
+            .click();
 
-            cy.contains('Test Task Title')
-                .click({ force: true });
+        // wait for window to transition open
+        cy.extGet('slate-window')
+            .should('not.have.class', 'x-hidden-clip')
+            .within(() => {
+                cy.root()
+                    .contains('.x-title-text', 'Edit Task');
 
-            cy.wait("@taskData")
-            cy.get('@taskData.all').should('have.length', 1)
+                cy.root()
+                    .contains('.x-form-item-label-text', 'Title')
+                    .click();
 
-            // click create button
-            cy.get('#' + editBtn.getId())
-                .click({ force: true });
+                cy.focused()
+                    .should('have.attr', 'name', 'Title')
+                    .type('Updated Test Task Title');
 
-            cy.get('.slate-window')
-                .contains('Edit Task');
+                cy.get('.slate-panelfooter')
+                    .contains('.x-btn-inner', 'Save')
+                    .click();
+            });
 
-            cy.get('.slate-window')
-                .contains('Title')
-                .click({ force: true })
+        // wait for data save
+        cy.wait('@taskSave');
 
-            cy.focused()
-                .should('have.attr', 'name', 'Title')
-                .type('Test Task Title - Updated');
+        // verify selected record is updated
+        cy.extGet('slate-tasks-manager', { component: true })
+            .should(grid => {
+                const selection = grid.getSelection();
+                expect(selection.length, 'one record selected').to.equal(1);
 
-            cy.get('.slate-window .slate-panelfooter')
-                .contains('Save')
-                .click({ force: true });
-
-            cy.wait("@taskSave")
-            cy.get('@taskSave.all').should('have.length', 1)
-        });
+                const [ task ] = selection;
+                expect(task.dirty, 'record is not dirty').to.be.false;
+                expect(task.get('Title'), 'title is updated').to.equal('Updated Test Task Title');
+            });
     });
 
     it('Delete public task as teacher', () => {
 
-        cy.intercept('POST', '/cbl/tasks/destroy?(\\?*)').as('taskDestroy')
-
         // open student demonstrations dashboard
         cy.visit('/cbl/dashboards/tasks/manager');
 
-        // verify teacher redirect
-        cy.location('hash').should('eq', '');
-
+        // verify app loaded
         cy.get('#slateapp-viewport')
-            .contains('Task Library');
+            .contains('.slate-appheader-title', 'Task Library');
 
-        cy.withExt().then(({Ext, extQuerySelector, extQuerySelectorAll}) => {
+        // wait for data load
+        cy.wait('@tasksData');
 
-            // get the selector element
-            var taskManager = extQuerySelector('slate-tasks-manager'),
-                appHeader = taskManager.down('slate-tasks-manager-appheader'),
-                deleteBtn = appHeader.down('button[action=delete]');
+        // find and click updated task
+        cy.extGet('slate-tasks-manager')
+            .contains('.x-grid-cell-inner', 'Updated Test Task Title')
+            .click();
 
+        // click delete button
+        cy.extGet('slate-tasks-manager-appheader button[action=delete]')
+            .click();
 
-            cy.contains('Test Task Title')
-                .click({ force: true });
+        // get confirmation prompt
+        cy.extGet('messagebox')
+            .within(() => {
+                cy.root()
+                    .contains('.x-title-text', 'Delete Task');
 
-            cy.wait("@taskData")
-            cy.get('@taskData.all').should('have.length', 1)
+                cy.root()
+                    .contains('.x-window-text strong', 'Updated Test Task Title');
 
-            // click create button
-            cy.get('#' + deleteBtn.getId())
-                .click({ force: true });
+                cy.root()
+                    .contains('.x-btn-inner', 'Yes')
+                    .click();
+            });
 
-            cy.get('.x-window')
-                .contains('Delete Task');
+        // wait for data save
+        cy.wait('@taskDestroy');
 
-            cy.get('.x-window .x-docked')
-                .contains('Yes')
-                .click({ force: true });
-
-            cy.wait("@taskDestroy").then(({ response }) => {
-                expect(response.body.success).to.eq(true)
-                expect(response.statusCode).to.eq(200)
-            })
-        });
+        // verify grid has no selection
+        cy.extGet('slate-tasks-manager', { component: true })
+            .should(grid => {
+                expect(grid.getSelection().length, 'no record selected').to.equal(0);
+            });
     });
 
 });

--- a/cypress/integration/cbl/teacher_tasks.js
+++ b/cypress/integration/cbl/teacher_tasks.js
@@ -12,216 +12,211 @@ describe('CBL: Teacher tasks test', () => {
         cy.intercept('POST', '/cbl/tasks/save?(\\?*)').as('taskSave');
         cy.intercept('GET', '/cbl/dashboards/tasks/teacher/bootstrap').as('getBootstrapData');
         cy.intercept('GET', '/sections?(\\?*)').as('getSections');
-        cy.intercept('GET', '/sections/*/cohorts').as('getSectionCohorts')
-        cy.intercept('GET', '/section-participants?(\\?*)').as('getSectionParticipants')
+        cy.intercept('GET', '/sections/*/cohorts').as('getSectionCohorts');
+        cy.intercept('GET', '/section-participants?(\\?*)').as('getSectionParticipants');
+
         cy.loginAs('teacher');
     });
 
     it('View single tasks as teacher', () => {
 
         // open student demonstrations dashboard
-        cy.visit('/cbl/dashboards/tasks/teacher')  ;
-        cy.wait('@getBootstrapData')
-        cy.get('@getBootstrapData.all').should('have.length', 1)
+        cy.visit('/cbl/dashboards/tasks/teacher');
+        cy.wait('@getBootstrapData');
+        cy.get('@getBootstrapData.all').should('have.length', 1);
 
         // verify teacher redirect
         cy.location('hash').should('eq', '');
 
-        cy.get('.slate-appcontainer-bodyWrap .slate-placeholder')
-            .contains('Select a section to load tasks dashboard');
+        cy.extGet('slate-tasks-teacher-dashboard')
+            .contains('.slate-placeholder', 'Select a section to load tasks dashboard');
 
-        cy.withExt().then(({Ext, extQuerySelector, extQuerySelectorAll}) => {
+        // click the 'Section' selector
+        cy.extGet('slate-cbl-sectionselector')
+            .click();
 
-            // get the selector element
-            var sectionSelector = extQuerySelector('slate-cbl-sectionselector');
+        cy.wait('@getSections');
+        cy.get('@getSections.all').should('have.length', 1);
 
-            // click the selector
-            cy.get('#' + sectionSelector.el.dom.id).click();
+        // click ELA section element of picker dropdown
+        cy.extGet('slate-cbl-sectionselector', { component: true })
+            .then(selector => selector.getPicker().el.dom)
+            .contains('.x-boundlist-item', 'English Language Arts')
+            .click();
 
-            cy.wait("@getSections")
-            cy.get('@getSections.all').should('have.length', 1)
+        cy.wait('@getSectionCohorts').its('response.statusCode').should('eq', 200);
+        cy.get('@getSectionCohorts.all').should('have.length', 1);
 
-            // click ELA section element of picker dropdown
-            cy.get('#' + sectionSelector.getPicker().id + ' .x-boundlist-item')
-                .contains('English Language Arts')
-                .click();
+        cy.wait('@getSectionParticipants').its('response.statusCode').should('eq', 200);
+        cy.get('@getSectionParticipants.all').should('have.length', 1);
 
-            cy.wait('@getSectionCohorts').its('response.statusCode').should('eq', 200)
-            cy.get('@getSectionCohorts.all').should('have.length', 1)
+        // verify hash
+        cy.location('hash').should('eq', '#ELA-001/all');
 
-            cy.wait('@getSectionParticipants').its('response.statusCode').should('eq', 200)
-            cy.get('@getSectionParticipants.all').should('have.length', 1)
-
-            // verify hash
-            cy.location('hash').should('eq', '#ELA-001/all');
-
-            // verify content loads
-            var studentGrid = extQuerySelector('slate-studentsgrid');
-            cy.get('#' + studentGrid.el.dom.id).contains('ELA Task One');
-        });
+        // verify content loads
+        cy.extGet('slate-studentsgrid')
+            .contains('.jarvus-aggregrid-header-text', 'ELA Task One');
     });
 
     it('Archive task as teacher', () => {
 
         // set up XHR monitors
-        cy.intercept('GET', '/cbl/skills?(\\?*)').as('getSkills')
+        cy.intercept('GET', '/cbl/skills?(\\?*)').as('getSkills');
 
         // open student demonstrations dashboard
         cy.visit('/cbl/dashboards/tasks/teacher');
-        cy.wait('@getBootstrapData')
-        cy.get('@getBootstrapData.all').should('have.length', 1)
+        cy.wait('@getBootstrapData');
+        cy.get('@getBootstrapData.all').should('have.length', 1);
 
         // verify teacher redirect
         cy.location('hash').should('eq', '');
 
-        cy.get('.slate-appcontainer-bodyWrap .slate-placeholder')
-            .contains('Select a section to load tasks dashboard');
+        cy.extGet('slate-tasks-teacher-dashboard')
+            .contains('.slate-placeholder', 'Select a section to load tasks dashboard');
 
-        cy.withExt().then(({Ext, extQuerySelector, extQuerySelectorAll}) => {
+        // click the 'Section' selector
+        cy.extGet('slate-cbl-sectionselector')
+            .click();
 
-            // get the selector element
-            var sectionSelector = extQuerySelector('slate-cbl-sectionselector');
+        cy.wait('@getSections');
+        cy.get('@getSections.all').should('have.length', 1);
 
-            // click the selector
-            cy.get('#' + sectionSelector.el.dom.id).click();
+        // click ELA section element of picker dropdown
+        cy.extGet('slate-cbl-sectionselector', { component: true })
+            .then(selector => selector.getPicker().el.dom)
+            .contains('.x-boundlist-item', 'English Language Arts')
+            .click();
 
-            cy.wait("@getSections")
-            cy.get('@getSections.all').should('have.length', 1)
-            // click ELA section element of picker dropdown
-            cy.get('#' + sectionSelector.getPicker().id + ' .x-boundlist-item')
-                .contains('English Language Arts')
-                .click();
+        cy.wait('@getSectionCohorts').its('response.statusCode').should('eq', 200);
+        cy.get('@getSectionCohorts.all').should('have.length', 1);
 
-            cy.wait('@getSectionCohorts').its('response.statusCode').should('eq', 200)
-            cy.get('@getSectionCohorts.all').should('have.length', 1)
+        cy.wait('@getSectionParticipants').its('response.statusCode').should('eq', 200);
+        cy.get('@getSectionParticipants.all').should('have.length', 1);
 
-            cy.wait('@getSectionParticipants').its('response.statusCode').should('eq', 200)
-            cy.get('@getSectionParticipants.all').should('have.length', 1)
-
-            // verify student tasks load
-            cy.wait('@studentTasksData').then(({ response }) => {
-                expect(response.body.success).to.eq(true)
-                expect(response.statusCode).to.eq(200)
-            })
-
-
-            // verify hash
-            cy.location('hash').should('eq', '#ELA-001/all');
-
-            // verify content loads
-            var studentGrid = extQuerySelector('slate-studentsgrid');
-            cy.get('#' + studentGrid.el.dom.id)
-                .contains('ELA Task One')
-                .contains('Edit')
-                .click({ force: true });
-
-            cy.wait('@taskData').then(({ response }) => {
-                expect(response.body.success).to.eq(true)
-                expect(response.statusCode).to.eq(200)
-            })
-
-            cy.get('.slate-window')
-                .contains('Archive Task')
-                .click({ force: true });
-
-
-            cy.wait('@taskSave').then(({ response }) => {
-                expect(response.body.success).to.eq(true)
-                expect(response.statusCode).to.eq(200)
-            })
-
-            cy.wait('@getSkills').then(({ response }) => {
-                expect(response.body.success).to.eq(true)
-                expect(response.statusCode).to.eq(200)
-            })
-
-            cy.get('#' + studentGrid.el.dom.id)
-                .contains('ELA Task One (archived)');
+        // verify student tasks load
+        cy.wait('@studentTasksData').then(({ response }) => {
+            expect(response.body.success).to.eq(true);
+            expect(response.statusCode).to.eq(200);
         });
+
+        // verify hash
+        cy.location('hash').should('eq', '#ELA-001/all');
+
+        // verify content loads
+        cy.extGet('slate-studentsgrid')
+            .contains('.jarvus-aggregrid-header-text', 'ELA Task One')
+            .contains('button', 'Edit')
+            .click({ force: true });
+
+        cy.wait('@taskData').then(({ response }) => {
+            expect(response.body.success).to.eq(true);
+            expect(response.statusCode).to.eq(200);
+        })
+
+        // wait for window to transition open
+        cy.extGet('slate-window')
+            .should('not.have.class', 'x-hidden-clip')
+            .contains('.x-btn-inner', 'Archive Task')
+            .click();
+
+        cy.wait('@taskSave').then(({ response }) => {
+            expect(response.body.success).to.eq(true);
+            expect(response.statusCode).to.eq(200);
+        });
+
+        cy.extGet('slate-studentsgrid')
+            .find('.jarvus-aggregrid-rowheader .jarvus-aggregrid-header-text')
+            .should($rowHeaders => {
+                const archived = $rowHeaders.filter(':contains(ELA Task One \(archived\))');
+                expect(archived.length, 'one archived task').to.eq(1);
+
+                const taskOne = $rowHeaders.filter(':contains(ELA Task One)');
+                expect(taskOne.length, 'only one "ELA Task One"').to.eq(1);
+            });
     });
 
     // requires Archive test to pass, or it will fail
     it('Un-Archive task as teacher', () => {
+
         // open student demonstrations dashboard
         cy.visit('/cbl/dashboards/tasks/teacher');
-        cy.wait('@getBootstrapData')
-        cy.get('@getBootstrapData.all').should('have.length', 1)
+        cy.wait('@getBootstrapData');
+        cy.get('@getBootstrapData.all').should('have.length', 1);
 
         // verify teacher redirect
         cy.location('hash').should('eq', '');
 
-        cy.get('.slate-appcontainer-bodyWrap .slate-placeholder')
-            .contains('Select a section to load tasks dashboard');
+        cy.extGet('slate-tasks-teacher-dashboard')
+            .contains('.slate-placeholder', 'Select a section to load tasks dashboard');
 
-        cy.withExt().then(({Ext, extQuerySelector, extQuerySelectorAll}) => {
+        // click the 'Section' selector
+        cy.extGet('slate-cbl-sectionselector')
+            .click();
 
-            // get the selector element
-            var sectionSelector = extQuerySelector('slate-cbl-sectionselector');
+        cy.wait('@getSections');
+        cy.get('@getSections.all').should('have.length', 1);
 
-            // click the selector
-            cy.get('#' + sectionSelector.el.dom.id).click();
+        // click ELA section element of picker dropdown
+        cy.extGet('slate-cbl-sectionselector', { component: true })
+            .then(selector => selector.getPicker().el.dom)
+            .contains('.x-boundlist-item', 'English Language Arts')
+            .click();
 
-            cy.wait("@getSections")
-            cy.get('@getSections.all').should('have.length', 1)
+        cy.wait('@getSectionCohorts').its('response.statusCode').should('eq', 200);
+        cy.get('@getSectionCohorts.all').should('have.length', 1);
 
-            // click ELA section element of picker dropdown
-            cy.get('#' + sectionSelector.getPicker().id + ' .x-boundlist-item')
-                .contains('English Language Arts')
-                .click();
+        cy.wait('@getSectionParticipants').its('response.statusCode').should('eq', 200);
+        cy.get('@getSectionParticipants.all').should('have.length', 1);
 
-            cy.wait('@getSectionCohorts').its('response.statusCode').should('eq', 200)
-            cy.get('@getSectionCohorts.all').should('have.length', 1)
-
-            cy.wait('@getSectionParticipants').its('response.statusCode').should('eq', 200)
-            cy.get('@getSectionParticipants.all').should('have.length', 1)
-
-
-            // verify student tasks load
-            cy.wait('@studentTasksData').then(({ response }) => {
-                expect(response.body.success).to.eq(true)
-                expect(response.statusCode).to.eq(200)
-            })
-
-            // verify hash
-            cy.location('hash').should('eq', '#ELA-001/all');
-
-            var gridToolbar = extQuerySelector('slate-gridtoolbar');
-            cy.get('#' + gridToolbar.el.dom.id)
-                .contains('Show Archived Tasks')
-                .click()
-
-
-               // verify student tasks load
-            cy.wait('@studentTasksData').then(({ response }) => {
-                expect(response.body.success).to.eq(true)
-                expect(response.statusCode).to.eq(200)
-            })
-
-            // verify content loads
-            var studentGrid = extQuerySelector('slate-studentsgrid');
-            cy.get('#' + studentGrid.el.dom.id)
-                .contains('ELA Task One (archived)')
-                .contains('Edit')
-                .click({ force: true });
-
-
-            cy.wait('@taskData').then(({ response }) => {
-                expect(response.body.success).to.eq(true)
-                expect(response.statusCode).to.eq(200)
-            })
-
-            cy.get('.slate-window')
-                .contains('Un-Archive Task')
-                .click({ force: true });
-
-
-            cy.wait('@taskSave').then(({ response }) => {
-                expect(response.body.success).to.eq(true)
-                expect(response.statusCode).to.eq(200)
-            })
-
-            cy.get('#' + studentGrid.el.dom.id)
-                .contains('ELA Task One');
+        // verify student tasks load
+        cy.wait('@studentTasksData').then(({ response }) => {
+            expect(response.body.success).to.eq(true);
+            expect(response.statusCode).to.eq(200);
         });
+
+        // verify hash
+        cy.location('hash').should('eq', '#ELA-001/all');
+
+        cy.extGet('slate-gridtoolbar')
+            .contains('.x-form-item-label-text', 'Show Archived Tasks')
+            .click();
+
+        // verify student tasks load
+        cy.wait('@studentTasksData').then(({ response }) => {
+            expect(response.body.success).to.eq(true)
+            expect(response.statusCode).to.eq(200)
+        });
+
+        // verify content loads
+        cy.extGet('slate-studentsgrid')
+            .contains('.jarvus-aggregrid-header-text', 'ELA Task One (archived)')
+            .contains('button', 'Edit')
+            .click({ force: true });
+
+        cy.wait('@taskData').then(({ response }) => {
+            expect(response.body.success).to.eq(true)
+            expect(response.statusCode).to.eq(200)
+        })
+
+        cy.extGet('slate-window')
+            .should('not.have.class', 'x-hidden-clip')
+            .contains('.x-btn-inner', 'Un-Archive Task')
+            .click();
+
+        cy.wait('@taskSave').then(({ response }) => {
+            expect(response.body.success).to.eq(true)
+            expect(response.statusCode).to.eq(200)
+        })
+
+        // verify content loads
+        cy.extGet('slate-studentsgrid')
+            .find('.jarvus-aggregrid-rowheader .jarvus-aggregrid-header-text')
+            .should($rowHeaders => {
+                const archived = $rowHeaders.filter(':contains(ELA Task One \(archived\))');
+                expect(archived.length, 'one archived task').to.eq(0);
+
+                const taskOne = $rowHeaders.filter(':contains(ELA Task One)');
+                expect(taskOne.length, 'only one "ELA Task One"').to.eq(1);
+            });
     });
 });


### PR DESCRIPTION
Updates remaining tests still using `cy.withExt()`—which allows substantial flattening of tests

I also found a lot of opportunities to improve the use of `.should(fn => { ... })` to create the correct waiting behavior (e.g. where the student tasks view tests change filters and then wait for a should() that checks that included tasks are present and excluded tasks are not present. Making both assertions in the same `.should()` within the forward assertion chain of the getter ensures the test waits for both conditions to become true before proceeding—replacing the need for arbitrary waits

Other improvements include:

- more streamlined use of dayjs (i.e. not formatting to text and then parsing again)
- making use of jquery instances Cypress already gives us instead of doing `cy.get($item)...`
- ensuring `.contains()` always gets a semantic selector passed too