### PR TITLE
fix: correct formula for demonstrations required

### DIFF
--- a/sencha-workspace/SlateDemonstrationsTeacher/app/view/ProgressGrid.js
+++ b/sencha-workspace/SlateDemonstrationsTeacher/app/view/ProgressGrid.js
@@ -769,7 +769,13 @@ Ext.define('SlateDemonstrationsTeacher.view.ProgressGrid', {
             countDirty = count != node.renderedCount;
             averageDirty = average != node.renderedAverage;
             levelDirty = level != renderedLevel;
-            demonstrationsRequired = competency.totalDemonstrationsRequired[level] || competency.totalDemonstrationsRequired.default;
+            demonstrationsRequired = competency.totalDemonstrationsRequired[level];
+            if (typeof demonstrationsRequired == 'undefined') {
+                demonstrationsRequired = competency.totalDemonstrationsRequired.default;
+                if (typeof demonstrationsRequired == 'undefined') {
+                    demonstrationsRequired = 1;
+                }
+            }
 
             if (countDirty || averageDirty) {
                 percentComplete = demonstrationsRequired === 0 ? 100 : 100 * (count || 0) / demonstrationsRequired;


### PR DESCRIPTION
There was an inconsistency in the way demonstrations required was being calculated in the
teachers and the students competency dashboards.  The teachers dashboard was evaluating
0 requirements as non-truthy and then using the default demonstrations required rather than zero.
This fix brings the same logic used in the student competencies dashboard to the teachers
competency dashboard.