### PR TITLE
fix: handle missed demonstrations with overrides correctly [SCHOOL-178]

### DIFF
--- a/cypress/fixtures/cbl/calculations.json
+++ b/cypress/fixtures/cbl/calculations.json
@@ -89,7 +89,7 @@
                 "average": "7",
                 "growth": "1",
                 "progress": "83",
-                "progressMissed": "999"
+                "progressMissed": "17"
             },
             "HOS.3": {
                 "description": "All M’s only with one ER for each skill",

--- a/cypress/fixtures/cbl/calculations.json
+++ b/cypress/fixtures/cbl/calculations.json
@@ -36,7 +36,7 @@
                 "average": "7",
                 "growth": "0",
                 "progress": "75",
-                "progressMissed": "25"
+                "progressMissed": "0"
             }
         }
     },

--- a/cypress/fixtures/cbl/calculations.json
+++ b/cypress/fixtures/cbl/calculations.json
@@ -66,6 +66,14 @@
                 "progress": "88",
                 "progressMissed": "0"
             },
+            "HW.2": {
+                "description": "Overrides with Ms only",
+                "baseline": null,
+                "average": null,
+                "growth": null,
+                "progress": "40",
+                "progressMissed": "30"
+            },
             "HW.3": {
                 "description": "Overrides only",
                 "baseline": null,
@@ -75,6 +83,14 @@
             }
         },
         "HOS": {
+            "HOS.2": {
+                "description": "Ratings and Ms for every evidence requirement in a skill with an override.",
+                "baseline": null,
+                "average": "7",
+                "growth": "1",
+                "progress": "83",
+                "progressMissed": "999"
+            },
             "HOS.3": {
                 "description": "All M’s only with one ER for each skill",
                 "baseline": null,

--- a/php-classes/Slate/CBL/StudentCompetency.php
+++ b/php-classes/Slate/CBL/StudentCompetency.php
@@ -329,9 +329,29 @@ class StudentCompetency extends \ActiveRecord
             $demonstrationsData = $this->getDemonstrationsData();
 
             foreach ($demonstrationsData as $skillId => &$demonstrationData) {
+                // Check if there are overrides
+                $overrideExists = false;
+                foreach ($demonstrationData as $item) {
+                    if ($item['Override'] === true) {
+                        $overrideExists = true;
+                        break;
+                    }
+                }
+
+                // If any overrides exist, bump all M ratings
+                if ($overrideExists) {
+                    $filteredDemonstrationData = array_filter($demonstrationData, function($datum) {
+                        if ($datum['DemonstratedLevel'] !== 0) {
+                            return true;
+                        }
+                    });
+                    $demonstrationData = $filteredDemonstrationData;
+                }
+
                 usort($demonstrationData, [__CLASS__,  'sortEffectiveDemonstrations']);
 
                 $Skill = Skill::getByID($skillId);
+
                 $demonstrationsRequired = $Skill->getDemonstrationsRequiredByLevel($this->Level);
 
                 array_splice($demonstrationData, $demonstrationsRequired);

--- a/php-classes/Slate/CBL/StudentCompetency.php
+++ b/php-classes/Slate/CBL/StudentCompetency.php
@@ -340,12 +340,9 @@ class StudentCompetency extends \ActiveRecord
 
                 // If any overrides exist, bump all M ratings
                 if ($overrideExists) {
-                    $filteredDemonstrationData = array_filter($demonstrationData, function($datum) {
-                        if ($datum['DemonstratedLevel'] !== 0) {
-                            return true;
-                        }
+                    $demonstrationData = array_filter($demonstrationData, function($datum) {
+                        return $datum['DemonstratedLevel'] !== 0;
                     });
-                    $demonstrationData = $filteredDemonstrationData;
                 }
 
                 usort($demonstrationData, [__CLASS__,  'sortEffectiveDemonstrations']);


### PR DESCRIPTION
Closes: SCHOOL-178

- [X] Add failing test cases
- [x] Fix failing test cases
- [x] Replace placeholder `999` with correct `progressMissed` for `HOS.2`