### PR TITLE
feat(e2e): add test cases for overrides [SCHOOL-125]

### DIFF
--- a/cypress/fixtures/cbl/calculations.json
+++ b/cypress/fixtures/cbl/calculations.json
@@ -38,6 +38,32 @@
                 "progress": "75",
                 "progressMissed": "0"
             }
+        },
+        "SS": {
+            "SS.1": {
+                "baseline": null,
+                "average": "6.5",
+                "growth": "0",
+                "progress": "53"
+            },
+            "SS.2": {
+                "baseline": null,
+                "average": "6",
+                "growth": "0",
+                "progress": "75"
+            },
+            "SS.3": {
+                "baseline": null,
+                "average": "9.3",
+                "growth": "0.3",
+                "progress": "75"
+            },
+            "SS.4": {
+                "baseline": null,
+                "average": "6.5",
+                "growth": "-0.5",
+                "progress": "50"
+            }
         }
     },
     "student2": {
@@ -98,6 +124,27 @@
                 "growth": null,
                 "progress": "0",
                 "progressMissed": "67"
+            }
+        },
+        "SS": {
+            "SS.1": {
+                "baseline": null,
+                "average": null,
+                "growth": null,
+                "progress": "80"
+            },
+            "SS.2": {
+                "baseline": null,
+                "average": null,
+                "growth": null,
+                "progress": "75"
+            },
+            "SS.4": {
+                "baseline": null,
+                "average": "9.5",
+                "growth": "0",
+                "progress": "50",
+                "progressMissed": "50"
             }
         }
     },

--- a/cypress/fixtures/cbl/calculations.json
+++ b/cypress/fixtures/cbl/calculations.json
@@ -143,8 +143,8 @@
                 "baseline": null,
                 "average": "9.5",
                 "growth": "0",
-                "progress": "50",
-                "progressMissed": "50"
+                "progress": "75",
+                "progressMissed": "25"
             }
         }
     },

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -67,9 +67,10 @@ describe('CBL / Progress / Overrides', () => {
             .find('.cbl-grid-progress-cell[data-student="'+student+'"]')
                 .should('have.length', 1)
                 .should('have.class', 'cbl-level-9')
-                .children()
-                    .should('contain.text', '75%')
-                    .and('contain.text', '6')
+                .within(() => {
+                    cy.get('.cbl-level-progress-percent').should('contain.text', '75%')
+                    cy.get('.cbl-level-progress-average').should('contain.text', '6')
+                });
 
         overrideSkill(competency, skill, student);
 
@@ -79,9 +80,10 @@ describe('CBL / Progress / Overrides', () => {
             .find('.cbl-grid-progress-cell[data-student="'+student+'"]')
                 .should('have.length', 1)
                 .should('have.class', 'cbl-level-9')
-                .children()
-                    .should('contain.text', '75%')
-                    .and('contain.text', '6')
+                .within(() => {
+                    cy.get('.cbl-level-progress-percent').should('contain.text', '75%')
+                    cy.get('.cbl-level-progress-average').should('contain.text', '6')
+                });
     });
 
     it('Override skill with multiple ERs and one rating.', () => {
@@ -109,9 +111,10 @@ describe('CBL / Progress / Overrides', () => {
             .find('.cbl-grid-progress-cell[data-student="'+student+'"]')
                 .should('have.length', 1)
                 .should('have.class', 'cbl-level-9')
-                .children()
-                    .should('contain.text', '67%')
-                    .and('contain.text', '6.5')
+                .within(() => {
+                    cy.get('.cbl-level-progress-percent').should('contain.text', '67%')
+                    cy.get('.cbl-level-progress-average').should('contain.text', '6.5')
+                });
     });
 
     it('Submit override resulting in graduation.', () => {
@@ -245,9 +248,10 @@ describe('CBL / Progress / Overrides', () => {
             .find('.cbl-grid-progress-cell[data-student="'+student+'"]')
                 .should('have.length', 1)
                 .should('have.class', 'cbl-level-10')
-                .children()
-                    .should('contain.text', '56%')
-                    .and('contain.text', '8.5')
+                .within(() => {
+                    cy.get('.cbl-level-progress-percent').should('contain.text', '56%')
+                    cy.get('.cbl-level-progress-average').should('contain.text', '8.5')
+                });
 
         // check skill boxes for correct values for ELA.6.1 - student2
         cy.get('.cbl-grid-main .cbl-grid-skills-row[data-competency="'+competency+'"]')

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -337,8 +337,8 @@ function overrideSkill(competency, skill, student) {
     cy.extGet('title[text="Skill History"] ^ slate-window')
         .should('have.length', 1)
         .should('not.have.class', 'x-hidden-clip')
-        .within(($window) => {
-            cy.extGet('tool[type="close"]')
+        .within(() => {
+            cy.get('.x-tool-close')
                 .should('exist')
                 .click();
         });

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -64,9 +64,9 @@ describe('CBL / Progress / Overrides', () => {
         const student = 4; // student
 
         // check values for progress and performance level for SS.2 - student
-        cy.get('.cbl-grid-main .cbl-grid-progress-row[data-competency="'+competency+'"]')
+        cy.get(`.cbl-grid-main .cbl-grid-progress-row[data-competency="${competency}"]`)
             .should('have.length', 1)
-            .find('.cbl-grid-progress-cell[data-student="'+student+'"]')
+            .find(`.cbl-grid-progress-cell[data-student="${student}"]`)
                 .should('have.length', 1)
                 .should('have.class', 'cbl-level-9')
                 .within(() => {
@@ -77,9 +77,9 @@ describe('CBL / Progress / Overrides', () => {
         overrideSkill(competency, skill, student);
 
         // ensure values for progress and performance remain the same
-        cy.get('.cbl-grid-main .cbl-grid-progress-row[data-competency="'+competency+'"]')
+        cy.get(`.cbl-grid-main .cbl-grid-progress-row[data-competency="${competency}"]`)
             .should('have.length', 1)
-            .find('.cbl-grid-progress-cell[data-student="'+student+'"]')
+            .find(`.cbl-grid-progress-cell[data-student="${student}"]`)
                 .should('have.length', 1)
                 .should('have.class', 'cbl-level-9')
                 .within(() => {
@@ -96,9 +96,9 @@ describe('CBL / Progress / Overrides', () => {
         const student = 4; //student
 
         // check values for progress and performance level for SS.2 - student
-        cy.get('.cbl-grid-main .cbl-grid-progress-row[data-competency="'+competency+'"]')
+        cy.get(`.cbl-grid-main .cbl-grid-progress-row[data-competency="${competency}"]`)
             .should('have.length', 1)
-            .find('.cbl-grid-progress-cell[data-student="'+student+'"]')
+            .find(`.cbl-grid-progress-cell[data-student="${student}"]`)
                 .should('have.length', 1)
                 .should('have.class', 'cbl-level-9')
                 .within(() => {
@@ -109,9 +109,9 @@ describe('CBL / Progress / Overrides', () => {
         overrideSkill(competency, skill, student);
 
         // ensure values for progress and performance have update appropriately
-        cy.get('.cbl-grid-main .cbl-grid-progress-row[data-competency="'+competency+'"]')
+        cy.get(`.cbl-grid-main .cbl-grid-progress-row[data-competency="${competency}"]`)
             .should('have.length', 1)
-            .find('.cbl-grid-progress-cell[data-student="'+student+'"]')
+            .find(`.cbl-grid-progress-cell[data-student="${student}"]`)
                 .should('have.length', 1)
                 .should('have.class', 'cbl-level-9')
                 .within(() => {
@@ -130,9 +130,9 @@ describe('CBL / Progress / Overrides', () => {
         overrideSkill(competency, skill, student);
 
         // ensure values for progress and performance have update appropriately
-        cy.get('.cbl-grid-main .cbl-grid-progress-row[data-competency="'+competency+'"]')
+        cy.get(`.cbl-grid-main .cbl-grid-progress-row[data-competency="${competency}"]`)
             .should('have.length', 1)
-            .find('.cbl-grid-progress-cell[data-student="'+student+'"]')
+            .find(`.cbl-grid-progress-cell[data-student="${student}"]`)
                 .should('have.length', 1)
                 .should('have.class', 'cbl-level-10')
                 .find('.cbl-grid-progress-percent')
@@ -149,9 +149,9 @@ describe('CBL / Progress / Overrides', () => {
         overrideSkill(competency, skill, student);
 
         // check portfolio value for graduation at cell at SS.4 - student
-        cy.get('.cbl-grid-main .cbl-grid-progress-row[data-competency="'+competency+'"]')
+        cy.get(`.cbl-grid-main .cbl-grid-progress-row[data-competency="${competency}"]`)
             .should('have.length', 1)
-            .find('.cbl-grid-progress-cell[data-student="'+student+'"]')
+            .find(`.cbl-grid-progress-cell[data-student="${student}"]`)
                 .should('have.length', 1)
                 .should('have.class', 'cbl-level-10')
                 .find('.cbl-grid-progress-percent')
@@ -168,9 +168,9 @@ describe('CBL / Progress / Overrides', () => {
         overrideSkill(competency, skill, student);
 
         // check portfolio value for graduation at cell at SS.4 - student
-        cy.get('.cbl-grid-main .cbl-grid-progress-row[data-competency="'+competency+'"]')
+        cy.get(`.cbl-grid-main .cbl-grid-progress-row[data-competency="${competency}"]`)
             .should('have.length', 1)
-            .find('.cbl-grid-progress-cell[data-student="'+student+'"]')
+            .find(`.cbl-grid-progress-cell[data-student="${student}"]`)
                 .should('have.length', 1)
                 .should('have.class', 'cbl-level-10')
                 .find('.cbl-grid-progress-percent')
@@ -185,15 +185,15 @@ describe('CBL / Progress / Overrides', () => {
         const student = 6; // student2
 
         // expand competency
-        cy.get('.cbl-grid-progress-row[data-competency="'+competency+'"] .cbl-grid-competency-name')
+        cy.get(`.cbl-grid-progress-row[data-competency="${competency}"] .cbl-grid-competency-name`)
             .should('have.length', 1)
             .click();
 
         // click cell for given skill/student
-        cy.get('.cbl-grid-main .cbl-grid-skills-row[data-competency="'+competency+'"]')
+        cy.get(`.cbl-grid-main .cbl-grid-skills-row[data-competency="${competency}"]`)
             .should('have.length', 1)
             .should('have.class', 'is-expanded')
-            .find('.cbl-grid-skill-row[data-skill="'+skill+'"] .cbl-grid-demos-cell[data-student="'+student+'"]')
+            .find(`.cbl-grid-skill-row[data-skill="${skill}"] .cbl-grid-demos-cell[data-student="${student}"]`)
                 .click();
 
         // wait for window to transition open
@@ -246,9 +246,9 @@ describe('CBL / Progress / Overrides', () => {
             });
 
         // check portfolio value for correct values for ELA.6.1 - student2
-        cy.get('.cbl-grid-main .cbl-grid-progress-row[data-competency="'+competency+'"]')
+        cy.get(`.cbl-grid-main .cbl-grid-progress-row[data-competency="${competency}"]`)
             .should('have.length', 1)
-            .find('.cbl-grid-progress-cell[data-student="'+student+'"]')
+            .find(`.cbl-grid-progress-cell[data-student="${student}"]`)
                 .should('have.length', 1)
                 .should('have.class', 'cbl-level-10')
                 .within(() => {
@@ -257,11 +257,11 @@ describe('CBL / Progress / Overrides', () => {
                 });
 
         // check skill boxes for correct values for ELA.6.1 - student2
-        cy.get('.cbl-grid-main .cbl-grid-skills-row[data-competency="'+competency+'"]')
+        cy.get(`.cbl-grid-main .cbl-grid-skills-row[data-competency="${competency}"]`)
             .should('have.length', 1)
-            .find('.cbl-grid-skill-row[data-skill="'+skill+'"]')
+            .find(`.cbl-grid-skill-row[data-skill="${skill}"]`)
                 .should('have.length', 1)
-                .find('.cbl-grid-demos-cell[data-student="'+student+'"]')
+                .find(`.cbl-grid-demos-cell[data-student="${student}"]`)
                     .should('have.length', 1)
                     .find('ul.cbl-skill-demos')
                         .children()
@@ -303,14 +303,14 @@ function loadDashboard(competencyArea, studentsList) {
 
 function overrideSkill(competency, skill, student) {
     // expand competency
-    cy.get('.cbl-grid-progress-row[data-competency="'+competency+'"] .cbl-grid-competency-name')
+    cy.get(`.cbl-grid-progress-row[data-competency="${competency}"] .cbl-grid-competency-name`)
         .should('have.length', 1)
         .click();
 
     // click cell for given skill/student
-    cy.get('.cbl-grid-main .cbl-grid-skills-row[data-competency="'+competency+'"]')
+    cy.get(`.cbl-grid-main .cbl-grid-skills-row[data-competency="${competency}"]`)
         .should('have.class', 'is-expanded')
-        .find('.cbl-grid-skill-row[data-skill="'+skill+'"] .cbl-grid-demos-cell[data-student="'+student+'"]')
+        .find(`.cbl-grid-skill-row[data-skill="${skill}"] .cbl-grid-demos-cell[data-student="${student}"]`)
             .click();
 
     // wait for history window to transition open

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -17,7 +17,7 @@ describe('CBL / Progress / Overrides', () => {
         cy.loginAs('teacher');
     });
 
-    it.skip('Override all skills in a competency with one ER and no other ratings to trigger graduation', () => {
+    it('Override all skills in a competency with one ER and no other ratings to trigger graduation', () => {
         loadTeacherDashboard('SS/group:class_of_2020');
 
         let competency = 30; // SS.2
@@ -36,7 +36,7 @@ describe('CBL / Progress / Overrides', () => {
                     .should('contain.text', '0%')
     });
 
-    it.skip('Override all skills in a competency with multiple ER and no other ratings to trigger graduation', () => {
+    it('Override all skills in a competency with multiple ER and no other ratings to trigger graduation', () => {
         loadTeacherDashboard('SS/group:class_of_2020');
 
         let competency = 29; // SS.1
@@ -55,7 +55,7 @@ describe('CBL / Progress / Overrides', () => {
                     .should('contain.text', '0%')
     });
 
-    it.skip('Override one skill in a competency with one ER and one rating should have no impact', () => {
+    it('Override one skill in a competency with one ER and one rating should have no impact', () => {
         loadTeacherDashboard('SS/group:class_of_2020');
 
         let competency = 30; // SS.2
@@ -85,7 +85,7 @@ describe('CBL / Progress / Overrides', () => {
                     .and('contain.text', '6')
     });
 
-    it.skip('Override skill with multiple ERs and one rating.', () => {
+    it('Override skill with multiple ERs and one rating.', () => {
         loadTeacherDashboard('SS/group:class_of_2020');
 
         let competency = 29; // SS.1
@@ -115,7 +115,7 @@ describe('CBL / Progress / Overrides', () => {
                     .and('contain.text', '6.5')
     });
 
-    it.skip('Submit override resulting in graduation.', () => {
+    it('Submit override resulting in graduation.', () => {
         loadTeacherDashboard('SS/group:class_of_2020');
 
         let competency = 31; // SS.3
@@ -134,7 +134,7 @@ describe('CBL / Progress / Overrides', () => {
                     .should('contain.text', '0%')
     });
 
-    it.skip('Override a skill with an M rating and one white box.', () => {
+    it('Override a skill with an M rating and one white box.', () => {
         loadTeacherDashboard('SS/group:class_of_2020');
 
         let competency = 32; // SS.4
@@ -153,7 +153,7 @@ describe('CBL / Progress / Overrides', () => {
                     .should('contain.text', '0%')
     });
 
-    it.skip('Override for all skills where one set of ERs has all Ms.', () => {
+    it('Override for all skills where one set of ERs has all Ms.', () => {
         loadTeacherDashboard('SS/group:class_of_2020');
 
         let competency = 32; // SS.4

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -209,14 +209,12 @@ describe('CBL / Progress / Overrides', () => {
         cy.extGet('title[text="Submit Evidence"] ^ slate-window')
             .should('not.have.class', 'x-hidden-clip')
             .within(($window) => {
-                // TODO: select using combo rather than typing
                 cy.extGet('slate-cbl-demonstrations-demonstrationform combobox[fieldLabel="Type of Experience"]')
                     .type('Studio');
 
                 cy.extGet('slate-cbl-demonstrations-demonstrationform combobox[fieldLabel="Name of Experience"]')
                     .type('Test');
 
-                // TODO: select using combo rather than typing
                 cy.extGet('slate-cbl-demonstrations-demonstrationform combobox[fieldLabel="Performance Task"]')
                     .type('Debate');
 

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -268,7 +268,7 @@ describe('CBL / Progress / Overrides', () => {
 
     });
 
-    // TODO: taking this function from teacher-dashboard.js ... unify?
+    // Todo: this function from teacher-dashboard.js... potential for unification
     function loadDashboard(hashPath) {
         // open student demonstrations dashboard
         cy.visit(`/cbl/dashboards/demonstrations/teacher${hashPath ? `#${hashPath}` : ''}`);
@@ -333,7 +333,7 @@ describe('CBL / Progress / Overrides', () => {
         cy.wait('@getDemonstrationSkills');
     };
 
-    // TODO: taking this function from teacher-submit.js ... unify?
+    // Todo: this function from teacher-submit.js... potential for unification
     function getSlidersRatingSelector(sliders) {
         const firstSlider = sliders[0];
         const { minRating, maxRating } = firstSlider.getConfig();

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -314,9 +314,8 @@ describe('CBL / Progress / Overrides', () => {
         // wait for history window to transition open
         cy.extGet('title[text="Skill History"] ^ slate-window')
             .should('not.have.class', 'x-hidden-clip')
-            .within(($window) => {
-                cy.extGet('button[text="Override"]')
-                    // .should('exist')
+            .within(() => {
+                cy.get('.x-btn-inner:contains("Override")')
                     .should('have.length', 1)
                     .click();
             });
@@ -324,12 +323,8 @@ describe('CBL / Progress / Overrides', () => {
         // wait for override window to transition open
         cy.extGet('title[text="Override Standard"] ^ slate-window')
             .should('not.have.class', 'x-hidden-clip')
-            .within(($window) => {
-                cy.extGet('slate-cbl-demonstrations-overrideform textarea[name="Comments"]')
-                    .type('Test Override');
-
-                cy.extGet('button[text="Submit Override"]')
-                    //.should('exist')
+            .within(() => {
+                cy.get('.x-btn-inner:contains("Submit Override")')
                     .should('have.length', 1)
                     .click();
             });

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -305,7 +305,6 @@ describe('CBL / Progress / Overrides', () => {
 
         // wait for window to transition open
         cy.extGet('slate-window title[text="Skill History"]')
-            .should('have.length', 1)
             .should('not.have.class', 'x-hidden-clip')
             .within(($window) => {
                 cy.extGet('button[text="Override"]')

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -272,77 +272,76 @@ describe('CBL / Progress / Overrides', () => {
                                 cy.get($children[1]).should('contain.text', '9');
                                 cy.get($children[2]).should('have.class', 'cbl-skill-demo-override');
                             })
-
     });
+});
 
-    function loadDashboard(competencyArea, studentsList) {
-        // open student demonstrations dashboard
-        cy.visit(`/cbl/dashboards/demonstrations/teacher#${competencyArea}/${studentsList}`);
+function loadDashboard(competencyArea, studentsList) {
+    // open student demonstrations dashboard
+    cy.visit(`/cbl/dashboards/demonstrations/teacher#${competencyArea}/${studentsList}`);
 
-        // ensure bootstrap data is loaded
-        cy.wait('@getBootstrapData');
-        cy.get('@getBootstrapData.all').should('have.length', 1);
+    // ensure bootstrap data is loaded
+    cy.wait('@getBootstrapData');
+    cy.get('@getBootstrapData.all').should('have.length', 1);
 
-        // verify teacher redirect
-        cy.location('hash').should('eq', `#${competencyArea}/${studentsList}`);
+    // verify teacher redirect
+    cy.location('hash').should('eq', `#${competencyArea}/${studentsList}`);
 
-        // ensure student competencies are loaded
-        cy.wait('@getStudentCompetencies');
-        cy.get('@getStudentCompetencies.all').should('have.length', 1);
+    // ensure student competencies are loaded
+    cy.wait('@getStudentCompetencies');
+    cy.get('@getStudentCompetencies.all').should('have.length', 1);
 
-        // verify placeholder is gone
-        cy.extGet('slate-demonstrations-teacher-dashboard')
-            .find('.slate-placeholder')
-                .should('not.be.visible');
+    // verify placeholder is gone
+    cy.extGet('slate-demonstrations-teacher-dashboard')
+        .find('.slate-placeholder')
+            .should('not.be.visible');
 
-        // verify competencies loaded
-        cy.extGet('slate-demonstrations-teacher-dashboard')
-            .find('.cbl-grid-competency-name')
-                .should('have.length.greaterThan', 0);
-    };
+    // verify competencies loaded
+    cy.extGet('slate-demonstrations-teacher-dashboard')
+        .find('.cbl-grid-competency-name')
+            .should('have.length.greaterThan', 0);
+};
 
-    function overrideSkill(competency, skill, student) {
-        // expand competency
-        cy.get('.cbl-grid-progress-row[data-competency="'+competency+'"] .cbl-grid-competency-name')
-            .should('have.length', 1)
+function overrideSkill(competency, skill, student) {
+    // expand competency
+    cy.get('.cbl-grid-progress-row[data-competency="'+competency+'"] .cbl-grid-competency-name')
+        .should('have.length', 1)
+        .click();
+
+    // click cell for given skill/student
+    cy.get('.cbl-grid-main .cbl-grid-skills-row[data-competency="'+competency+'"]')
+        .should('have.class', 'is-expanded')
+        .find('.cbl-grid-skill-row[data-skill="'+skill+'"] .cbl-grid-demos-cell[data-student="'+student+'"]')
             .click();
 
-        // click cell for given skill/student
-        cy.get('.cbl-grid-main .cbl-grid-skills-row[data-competency="'+competency+'"]')
-            .should('have.class', 'is-expanded')
-            .find('.cbl-grid-skill-row[data-skill="'+skill+'"] .cbl-grid-demos-cell[data-student="'+student+'"]')
+    // wait for history window to transition open
+    cy.extGet('title[text="Skill History"] ^ slate-window')
+        .should('not.have.class', 'x-hidden-clip')
+        .within(() => {
+            cy.get('.x-btn-inner:contains("Override")')
+                .should('have.length', 1)
                 .click();
+        });
 
-        // wait for history window to transition open
-        cy.extGet('title[text="Skill History"] ^ slate-window')
-            .should('not.have.class', 'x-hidden-clip')
-            .within(() => {
-                cy.get('.x-btn-inner:contains("Override")')
-                    .should('have.length', 1)
-                    .click();
-            });
+    // wait for override window to transition open
+    cy.extGet('title[text="Override Standard"] ^ slate-window')
+        .should('not.have.class', 'x-hidden-clip')
+        .within(() => {
+            cy.get('.x-btn-inner:contains("Submit Override")')
+                .should('have.length', 1)
+                .click();
+        });
 
-        // wait for override window to transition open
-        cy.extGet('title[text="Override Standard"] ^ slate-window')
-            .should('not.have.class', 'x-hidden-clip')
-            .within(() => {
-                cy.get('.x-btn-inner:contains("Submit Override")')
-                    .should('have.length', 1)
-                    .click();
-            });
+    cy.wait('@saveDemonstration');
 
-        cy.wait('@saveDemonstration');
+    // close the history window
+    cy.extGet('title[text="Skill History"] ^ slate-window')
+        .should('have.length', 1)
+        .should('not.have.class', 'x-hidden-clip')
+        .within(($window) => {
+            cy.extGet('tool[type="close"]')
+                .should('exist')
+                .click();
+        });
 
-        // close the history window
-        cy.extGet('title[text="Skill History"] ^ slate-window')
-            .should('have.length', 1)
-            .should('not.have.class', 'x-hidden-clip')
-            .within(($window) => {
-                cy.extGet('tool[type="close"]')
-                    .should('exist')
-                    .click();
-            });
-
-        cy.wait('@getDemonstrationSkills');
-    };
-});
+    cy.wait('@getDemonstrationSkills');
+};

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -290,19 +290,23 @@ describe('CBL / Progress / Overrides', () => {
             .contains('.slate-placeholder', 'Select a list of students and a content area to load progress dashboard');
     };
 
-    function overrideSkill(competency, skill, student) {
+    function overrideSkillExpandcompetency(competency, skill, student) {
         // expand competency
         cy.get('.cbl-grid-progress-row[data-competency="'+competency+'"] .cbl-grid-competency-name')
             .should('have.length', 1)
             .click();
+    };
 
+    function overrideSkillClickCell(competency, skill, student) {
         // click cell for given skill/student
         cy.get('.cbl-grid-main .cbl-grid-skills-row[data-competency="'+competency+'"]')
             .should('have.class', 'is-expanded')
             .find('.cbl-grid-skill-row[data-skill="'+skill+'"] .cbl-grid-demos-cell[data-student="'+student+'"]')
                 .click();
+    };
 
-        // wait for window to transition open
+    function overrideSkillHistoryWindow(competency, skill, student) {
+        // wait for history window to transition open
         cy.extGet('slate-window title[text="Skill History"]')
             .should('not.have.class', 'x-hidden-clip')
             .within(($window) => {
@@ -310,6 +314,31 @@ describe('CBL / Progress / Overrides', () => {
                     .should('exist')
                     .click();
             });
+    };
+
+    function overrideSkill(competency, skill, student) {
+        // expand competency
+        // cy.get('.cbl-grid-progress-row[data-competency="'+competency+'"] .cbl-grid-competency-name')
+        //     .should('have.length', 1)
+        //     .click();
+        overrideSkillExpandcompetency(competency, skill, student);
+
+        // click cell for given skill/student
+        // cy.get('.cbl-grid-main .cbl-grid-skills-row[data-competency="'+competency+'"]')
+        //     .should('have.class', 'is-expanded')
+        //     .find('.cbl-grid-skill-row[data-skill="'+skill+'"] .cbl-grid-demos-cell[data-student="'+student+'"]')
+        //         .click();
+        overrideSkillClickCell(competency, skill, student)
+
+        // wait for window to transition open
+        // cy.extGet('slate-window title[text="Skill History"]')
+        //     .should('not.have.class', 'x-hidden-clip')
+        //     .within(($window) => {
+        //         cy.extGet('button[text="Override"]')
+        //             .should('exist')
+        //             .click();
+        //     });
+        overrideSkillHistoryWindow(competency, skill, student)
 
         // wait for window to transition open
         cy.extGet('slate-window title[text="Override Standard"]')

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -19,16 +19,16 @@ describe('CBL / Progress / Overrides', () => {
     it('Override all skills in a competency with one ER and no other ratings to trigger graduation', () => {
         loadDashboard('SS/group:class_of_2020');
 
-        let competency = 30; // SS.2
-        let skill = 166; // SS.2.4
-        let student = 6; // student2
+        const competency = 30; // SS.2
+        const skill = 166; // SS.2.4
+        const student = 6; // student2
 
         overrideSkill(competency, skill, student);
 
         // check portfolio value for graduation at cell at SS.2 - student2
-        cy.get('.cbl-grid-main .cbl-grid-progress-row[data-competency="30"]')
+        cy.get(`.cbl-grid-main .cbl-grid-progress-row[data-competency="${competency}"]`)
             .should('have.length', 1)
-            .find('.cbl-grid-progress-cell[data-student="6"]')
+            .find(`.cbl-grid-progress-cell[data-student="${student}"]`)
                 .should('have.length', 1)
                 .should('have.class', 'cbl-level-10')
                 .find('.cbl-grid-progress-percent')

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -47,9 +47,9 @@ describe('CBL / Progress / Overrides', () => {
         overrideSkill(competency, skill, student);
 
         // check portfolio value for graduation at cell at SS.1 - student2
-        cy.get('.cbl-grid-main .cbl-grid-progress-row[data-competency="29"]')
+        cy.get(`.cbl-grid-main .cbl-grid-progress-row[data-competency="${competency}"]`)
             .should('have.length', 1)
-            .find('.cbl-grid-progress-cell[data-student="6"]')
+            .find(`.cbl-grid-progress-cell[data-student="${student}"]`)
                 .should('have.length', 1)
                 .should('have.class', 'cbl-level-10')
                 .find('.cbl-grid-progress-percent')

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -1,3 +1,5 @@
+const { getSlidersRatingSelector } = require('../../../support/ratings.js')
+
 describe('CBL / Progress / Overrides', () => {
 
     // load sample database before tests
@@ -342,24 +344,5 @@ describe('CBL / Progress / Overrides', () => {
             });
 
         cy.wait('@getDemonstrationSkills');
-    };
-
-    // Todo: this function from teacher-submit.js... potential for unification
-    function getSlidersRatingSelector(sliders) {
-        const firstSlider = sliders[0];
-        const { minRating, maxRating } = firstSlider.getConfig();
-        const visibleRatings = Array.from({length: maxRating - minRating + 1 }, (_, i) => i + minRating)
-        const totalThumbs = visibleRatings.length;
-        const ratingWidth = firstSlider.innerEl.getWidth() / totalThumbs;
-
-        return (slider, rating) => {
-            const selectedRatingPos = visibleRatings.indexOf(rating);
-            cy.wrap(slider.innerEl.dom)
-                .click({
-                    x: ratingWidth * (selectedRatingPos + 1),
-                    y: 5,
-                    force: true
-                });
-        };
     };
 });

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -241,6 +241,16 @@ describe('CBL / Progress / Overrides', () => {
             });
 
         // check portfolio value for correct values for ELA.6.1 - student2
+        cy.get('.cbl-grid-main .cbl-grid-progress-row[data-competency="'+competency+'"]')
+            .should('have.length', 1)
+            .find('.cbl-grid-progress-cell[data-student="'+student+'"]')
+                .should('have.length', 1)
+                .should('have.class', 'cbl-level-10')
+                .children()
+                    .should('contain.text', '56%')
+                    .and('contain.text', '8.5')
+
+        // check skill boxes for correct values for ELA.6.1 - student2
         cy.get('.cbl-grid-main .cbl-grid-skills-row[data-competency="'+competency+'"]')
             .should('have.length', 1)
             .find('.cbl-grid-skill-row[data-skill="'+skill+'"]')

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -314,6 +314,7 @@ function overrideSkill(competency, skill, student) {
 
     // wait for history window to transition open
     cy.extGet('title[text="Skill History"] ^ slate-window')
+        .should('have.length', 1)
         .should('not.have.class', 'x-hidden-clip')
         .within(() => {
             cy.get('.x-btn-inner:contains("Override")')
@@ -323,6 +324,7 @@ function overrideSkill(competency, skill, student) {
 
     // wait for override window to transition open
     cy.extGet('title[text="Override Standard"] ^ slate-window')
+        .should('have.length', 1)
         .should('not.have.class', 'x-hidden-clip')
         .within(() => {
             cy.get('.x-btn-inner:contains("Submit Override")')

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -40,9 +40,9 @@ describe('CBL / Progress / Overrides', () => {
     it('Override all skills in a competency with multiple ER and no other ratings to trigger graduation', () => {
         loadDashboard('SS', 'group:class_of_2020');
 
-        let competency = 29; // SS.1
-        let skill = 162; // SS.1.5
-        let student = 6; // student2
+        const competency = 29; // SS.1
+        const skill = 162; // SS.1.5
+        const student = 6; // student2
 
         overrideSkill(competency, skill, student);
 
@@ -59,9 +59,9 @@ describe('CBL / Progress / Overrides', () => {
     it('Override one skill in a competency with one ER and one rating should have no impact', () => {
         loadDashboard('SS', 'group:class_of_2020');
 
-        let competency = 30; // SS.2
-        let skill = 165; // SS.2.3
-        let student = 4; // student
+        const competency = 30; // SS.2
+        const skill = 165; // SS.2.3
+        const student = 4; // student
 
         // check values for progress and performance level for SS.2 - student
         cy.get('.cbl-grid-main .cbl-grid-progress-row[data-competency="'+competency+'"]')
@@ -91,9 +91,9 @@ describe('CBL / Progress / Overrides', () => {
     it('Override skill with multiple ERs and one rating.', () => {
         loadDashboard('SS', 'group:class_of_2020');
 
-        let competency = 29; // SS.1
-        let skill = 160; // SS.1.3
-        let student = 4; //student
+        const competency = 29; // SS.1
+        const skill = 160; // SS.1.3
+        const student = 4; //student
 
         // check values for progress and performance level for SS.2 - student
         cy.get('.cbl-grid-main .cbl-grid-progress-row[data-competency="'+competency+'"]')
@@ -123,9 +123,9 @@ describe('CBL / Progress / Overrides', () => {
     it('Submit override resulting in graduation.', () => {
         loadDashboard('SS', 'group:class_of_2020');
 
-        let competency = 31; // SS.3
-        let skill = 168;    // SS.3.2
-        let student = 4; // student
+        const competency = 31; // SS.3
+        const skill = 168;    // SS.3.2
+        const student = 4; // student
 
         overrideSkill(competency, skill, student);
 
@@ -142,9 +142,9 @@ describe('CBL / Progress / Overrides', () => {
     it('Override a skill with an M rating and one white box.', () => {
         loadDashboard('SS', 'group:class_of_2020');
 
-        let competency = 32; // SS.4
-        let skill = 169; // SS.4.1
-        let student = 4; // student
+        const competency = 32; // SS.4
+        const skill = 169; // SS.4.1
+        const student = 4; // student
 
         overrideSkill(competency, skill, student);
 
@@ -161,9 +161,9 @@ describe('CBL / Progress / Overrides', () => {
     it('Override for all skills where one set of ERs has all Ms.', () => {
         loadDashboard('SS', 'group:class_of_2020');
 
-        let competency = 32; // SS.4
-        let skill = 170; // SS.4.2
-        let student = 6; // student2
+        const competency = 32; // SS.4
+        const skill = 170; // SS.4.2
+        const student = 6; // student2
 
         overrideSkill(competency, skill, student);
 
@@ -180,9 +180,9 @@ describe('CBL / Progress / Overrides', () => {
     it('Submit a rating for a skill with an override.', () => {
         loadDashboard('ELA', 'group:class_of_2020');
 
-        let competency = 6; // ELA.6
-        let skill = 28; // ELA.6.1
-        let student = 6; // student2
+        const competency = 6; // ELA.6
+        const skill = 28; // ELA.6.1
+        const student = 6; // student2
 
         // expand competency
         cy.get('.cbl-grid-progress-row[data-competency="'+competency+'"] .cbl-grid-competency-name')

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -1,0 +1,345 @@
+describe('CBL / Progress / Overrides', () => {
+
+    // load sample database before tests
+    before(() => {
+        cy.resetDatabase();
+    });
+
+    // authenticate as 'teacher' user
+    beforeEach(() => {
+        // set up XHR monitors
+        cy.intercept('GET', '/cbl/dashboards/demonstrations/teacher/bootstrap').as('getBootstrapData');
+        cy.intercept('GET', '/cbl/content-areas?(\\?*)').as('getContentAreas');     // todo: needed?
+        cy.intercept('/cbl/student-competencies?(\\?*)').as('getStudentCompetencies');
+        cy.intercept('/cbl/demonstration-skills?(\\?*)').as('getDemonstrationSkills');
+        cy.intercept('POST', '/cbl/demonstrations/save?(\\?*)').as('saveDemonstration');
+
+        cy.loginAs('teacher');
+    });
+
+    it.skip('Override all skills in a competency with one ER and no other ratings to trigger graduation', () => {
+        loadTeacherDashboard('SS/group:class_of_2020');
+
+        let competency = 30; // SS.2
+        let skill = 166; // SS.2.4
+        let student = 6; // student2
+
+        overrideSkill(competency, skill, student);
+
+        // check portfolio value for graduation at cell at SS.2 - student2
+        cy.get('.cbl-grid-main .cbl-grid-progress-row[data-competency="30"]')
+            .should('have.length', 1)
+            .find('.cbl-grid-progress-cell[data-student="6"]')
+                .should('have.length', 1)
+                .should('have.class', 'cbl-level-10')
+                .find('.cbl-grid-progress-percent')
+                    .should('contain.text', '0%')
+    });
+
+    it.skip('Override all skills in a competency with multiple ER and no other ratings to trigger graduation', () => {
+        loadTeacherDashboard('SS/group:class_of_2020');
+
+        let competency = 29; // SS.1
+        let skill = 162; // SS.1.5
+        let student = 6; // student2
+
+        overrideSkill(competency, skill, student);
+
+        // check portfolio value for graduation at cell at SS.1 - student2
+        cy.get('.cbl-grid-main .cbl-grid-progress-row[data-competency="29"]')
+            .should('have.length', 1)
+            .find('.cbl-grid-progress-cell[data-student="6"]')
+                .should('have.length', 1)
+                .should('have.class', 'cbl-level-10')
+                .find('.cbl-grid-progress-percent')
+                    .should('contain.text', '0%')
+    });
+
+    it.skip('Override one skill in a competency with one ER and one rating should have no impact', () => {
+        loadTeacherDashboard('SS/group:class_of_2020');
+
+        let competency = 30; // SS.2
+        let skill = 165; // SS.2.3
+        let student = 4; // student
+
+        // check values for progress and performance level for SS.2 - student
+        cy.get('.cbl-grid-main .cbl-grid-progress-row[data-competency="'+competency+'"]')
+            .should('have.length', 1)
+            .find('.cbl-grid-progress-cell[data-student="'+student+'"]')
+                .should('have.length', 1)
+                .should('have.class', 'cbl-level-9')
+                .children()
+                    .should('contain.text', '75%')
+                    .and('contain.text', '6')
+
+        overrideSkill(competency, skill, student);
+
+        // ensure values for progress and performance remain the same
+        cy.get('.cbl-grid-main .cbl-grid-progress-row[data-competency="'+competency+'"]')
+            .should('have.length', 1)
+            .find('.cbl-grid-progress-cell[data-student="'+student+'"]')
+                .should('have.length', 1)
+                .should('have.class', 'cbl-level-9')
+                .children()
+                    .should('contain.text', '75%')
+                    .and('contain.text', '6')
+    });
+
+    it.skip('Override skill with multiple ERs and one rating.', () => {
+        loadTeacherDashboard('SS/group:class_of_2020');
+
+        let competency = 29; // SS.1
+        let skill = 160; // SS.1.3
+        let student = 4; //student
+
+        // check values for progress and performance level for SS.2 - student
+        cy.get('.cbl-grid-main .cbl-grid-progress-row[data-competency="'+competency+'"]')
+            .should('have.length', 1)
+            .find('.cbl-grid-progress-cell[data-student="'+student+'"]')
+                .should('have.length', 1)
+                .should('have.class', 'cbl-level-9')
+                .children()
+                    .should('contain.text', '53%')
+                    .and('contain.text', '6.5')
+
+        overrideSkill(competency, skill, student);
+
+        // ensure values for progress and performance have update appropriately
+        cy.get('.cbl-grid-main .cbl-grid-progress-row[data-competency="'+competency+'"]')
+            .should('have.length', 1)
+            .find('.cbl-grid-progress-cell[data-student="'+student+'"]')
+                .should('have.length', 1)
+                .should('have.class', 'cbl-level-9')
+                .children()
+                    .should('contain.text', '67%')
+                    .and('contain.text', '6.5')
+    });
+
+    it.skip('Submit override resulting in graduation.', () => {
+        loadTeacherDashboard('SS/group:class_of_2020');
+
+        let competency = 31; // SS.3
+        let skill = 168;    // SS.3.2
+        let student = 4; // student
+
+        overrideSkill(competency, skill, student);
+
+        // ensure values for progress and performance have update appropriately
+        cy.get('.cbl-grid-main .cbl-grid-progress-row[data-competency="'+competency+'"]')
+            .should('have.length', 1)
+            .find('.cbl-grid-progress-cell[data-student="'+student+'"]')
+                .should('have.length', 1)
+                .should('have.class', 'cbl-level-10')
+                .find('.cbl-grid-progress-percent')
+                    .should('contain.text', '0%')
+    });
+
+    it.skip('Override a skill with an M rating and one white box.', () => {
+        loadTeacherDashboard('SS/group:class_of_2020');
+
+        let competency = 32; // SS.4
+        let skill = 169; // SS.4.1
+        let student = 4; // student
+
+        overrideSkill(competency, skill, student);
+
+        // check portfolio value for graduation at cell at SS.4 - student
+        cy.get('.cbl-grid-main .cbl-grid-progress-row[data-competency="'+competency+'"]')
+            .should('have.length', 1)
+            .find('.cbl-grid-progress-cell[data-student="'+student+'"]')
+                .should('have.length', 1)
+                .should('have.class', 'cbl-level-10')
+                .find('.cbl-grid-progress-percent')
+                    .should('contain.text', '0%')
+    });
+
+    it.skip('Override for all skills where one set of ERs has all Ms.', () => {
+        loadTeacherDashboard('SS/group:class_of_2020');
+
+        let competency = 32; // SS.4
+        let skill = 170; // SS.4.2
+        let student = 6; // student2
+
+        overrideSkill(competency, skill, student);
+
+        // check portfolio value for graduation at cell at SS.4 - student
+        cy.get('.cbl-grid-main .cbl-grid-progress-row[data-competency="'+competency+'"]')
+            .should('have.length', 1)
+            .find('.cbl-grid-progress-cell[data-student="'+student+'"]')
+                .should('have.length', 1)
+                .should('have.class', 'cbl-level-10')
+                .find('.cbl-grid-progress-percent')
+                    .should('contain.text', '0%')
+    });
+
+    it('Submit a rating for a skill with an override.', () => {
+        loadTeacherDashboard('ELA/group:class_of_2020');
+
+        let competency = 6; // ELA.6
+        let skill = 28; // ELA.6.1
+        let student = 6; // student2
+
+        // expand competency
+        cy.get('.cbl-grid-progress-row[data-competency="'+competency+'"] .cbl-grid-competency-name')
+            .should('have.length', 1)
+            .click();
+
+        // click cell for given skill/student
+        cy.get('.cbl-grid-main .cbl-grid-skills-row[data-competency="'+competency+'"]')
+            .should('have.length', 1)
+            .should('have.class', 'is-expanded')
+            .find('.cbl-grid-skill-row[data-skill="'+skill+'"] .cbl-grid-demos-cell[data-student="'+student+'"]')
+                .click();
+
+        // wait for window to transition open
+        cy.extGet('slate-window title[text="Skill History"]')
+            .should('not.have.class', 'x-hidden-clip')
+            .within(($window) => {
+                cy.extGet('button[text="Submit Evidence"]')
+                    .should('exist')
+                    .click();
+            });
+
+        // wait for window to transition open
+        cy.extGet('slate-window title[text="Submit Evidence"]')
+            .should('not.have.class', 'x-hidden-clip')
+            .within(($window) => {
+                // TODO: select using combo rather than typing
+                cy.extGet('slate-cbl-demonstrations-demonstrationform combobox[fieldLabel="Type of Experience"]')
+                    .type('Studio');
+
+                cy.extGet('slate-cbl-demonstrations-demonstrationform combobox[fieldLabel="Name of Experience"]')
+                    .type('Test');
+
+                // TODO: select using combo rather than typing
+                cy.extGet('slate-cbl-demonstrations-demonstrationform combobox[fieldLabel="Performance Task"]')
+                    .type('Debate');
+
+                cy.extGet('slate-cbl-ratings-slider', { all: true, component: true })
+                        .should('have.length', 3)
+                        .then(sliders => {
+                            const _selectRating = getSlidersRatingSelector(sliders);
+
+                            _selectRating(sliders[0], 9);
+                        });
+
+                cy.extGet('slate-cbl-demonstrations-demonstrationform textarea[fieldLabel="Comments"]')
+                    .type('Test rating');
+
+                cy.extGet('button[text="Save Evidence"]')
+                    .should('exist')
+                    .click();
+            });
+
+        // close the window
+        cy.extGet('slate-window title[text="Skill History"]')
+            .should('not.have.class', 'x-hidden-clip')
+            .within(($window) => {
+                cy.extGet('tool[type="close"]')
+                    .should('exist')
+                    .click();
+            });
+
+        // check portfolio value for correct values for ELA.6.1 - student2
+        cy.get('.cbl-grid-main .cbl-grid-skills-row[data-competency="'+competency+'"]')
+            .should('have.length', 1)
+            .find('.cbl-grid-skill-row[data-skill="'+skill+'"]')
+                .should('have.length', 1)
+                .find('.cbl-grid-demos-cell[data-student="'+student+'"]')
+                    .should('have.length', 1)
+                    .find('ul.cbl-skill-demos')
+                        .children()
+                            .should('have.length', 3)
+                            .then(($children) => {
+                                // The 9 should fill the second box and the override should only fill the third box.
+                                cy.get($children[0]).should('contain.text', '10');
+                                cy.get($children[1]).should('contain.text', '9');
+                                cy.get($children[2]).should('have.class', 'cbl-skill-demo-override');
+                            })
+
+    });
+
+    // TODO: taking this function from teacher-dashboard.js ... unify?
+    function loadTeacherDashboard(hashPath) {
+        // open student demonstrations dashboard
+        cy.visit(`/cbl/dashboards/demonstrations/teacher${hashPath ? `#${hashPath}` : ''}`);
+
+        // ensure bootstrap data is loaded
+        cy.wait('@getBootstrapData');
+        cy.get('@getBootstrapData.all').should('have.length', 1);
+
+        // verify teacher redirect
+        cy.location('hash').should('eq', hashPath ? `#${hashPath}` : '#_');
+
+        // verify placeholder
+        cy.extGet('slate-demonstrations-teacher-dashboard')
+            .contains('.slate-placeholder', 'Select a list of students and a content area to load progress dashboard');
+    };
+
+    function overrideSkill(competency, skill, student) {
+        // expand competency
+        cy.get('.cbl-grid-progress-row[data-competency="'+competency+'"] .cbl-grid-competency-name')
+            .should('have.length', 1)
+            .click();
+
+        // click cell for given skill/student
+        cy.get('.cbl-grid-main .cbl-grid-skills-row[data-competency="'+competency+'"]')
+            .should('have.length', 1)
+            .should('have.class', 'is-expanded')
+            .find('.cbl-grid-skill-row[data-skill="'+skill+'"] .cbl-grid-demos-cell[data-student="'+student+'"]')
+                .click();
+
+        // wait for window to transition open
+        cy.extGet('slate-window title[text="Skill History"]')
+            .should('not.have.class', 'x-hidden-clip')
+            .within(($window) => {
+                cy.extGet('button[text="Override"]')
+                    .should('exist')
+                    .click();
+            });
+
+        // wait for window to transition open
+        cy.extGet('slate-window title[text="Override Standard"]')
+            .should('not.have.class', 'x-hidden-clip')
+            .within(($window) => {
+                cy.extGet('slate-cbl-demonstrations-overrideform textarea[name="Comments"]')
+                    .type('Test Override');
+
+                cy.extGet('button[text="Submit Override"]')
+                    .should('exist')
+                    .click();
+            });
+
+        cy.wait('@saveDemonstration');
+
+        // close the window
+        cy.extGet('slate-window title[text="Skill History"]')
+            .should('not.have.class', 'x-hidden-clip')
+            .within(($window) => {
+                cy.extGet('tool[type="close"]')
+                    .should('exist')
+                    .click();
+            });
+
+        cy.wait('@getDemonstrationSkills');
+    };
+
+    // TODO: taking this function from teacher-submit.js ... unify?
+    function getSlidersRatingSelector(sliders) {
+        const firstSlider = sliders[0];
+        const { minRating, maxRating } = firstSlider.getConfig();
+        const visibleRatings = Array.from({length: maxRating - minRating + 1 }, (_, i) => i + minRating)
+        const totalThumbs = visibleRatings.length;
+        const ratingWidth = firstSlider.innerEl.getWidth() / totalThumbs;
+
+        return (slider, rating) => {
+            const selectedRatingPos = visibleRatings.indexOf(rating);
+            cy.wrap(slider.innerEl.dom)
+                .click({
+                    x: ratingWidth * (selectedRatingPos + 1),
+                    y: 5,
+                    force: true
+                });
+        };
+    };
+});

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -9,7 +9,6 @@ describe('CBL / Progress / Overrides', () => {
     beforeEach(() => {
         // set up XHR monitors
         cy.intercept('GET', '/cbl/dashboards/demonstrations/teacher/bootstrap').as('getBootstrapData');
-        cy.intercept('GET', '/cbl/content-areas?(\\?*)').as('getContentAreas');     // todo: needed?
         cy.intercept('/cbl/student-competencies?(\\?*)').as('getStudentCompetencies');
         cy.intercept('/cbl/demonstration-skills?(\\?*)').as('getDemonstrationSkills');
         cy.intercept('POST', '/cbl/demonstrations/save?(\\?*)').as('saveDemonstration');

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -99,9 +99,10 @@ describe('CBL / Progress / Overrides', () => {
             .find('.cbl-grid-progress-cell[data-student="'+student+'"]')
                 .should('have.length', 1)
                 .should('have.class', 'cbl-level-9')
-                .children()
-                    .should('contain.text', '53%')
-                    .and('contain.text', '6.5')
+                .within(() => {
+                    cy.get('.cbl-level-progress-percent').should('contain.text', '53%')
+                    cy.get('.cbl-level-progress-average').should('contain.text', '6.5')
+                });
 
         overrideSkill(competency, skill, student);
 

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -17,7 +17,7 @@ describe('CBL / Progress / Overrides', () => {
     });
 
     it('Override all skills in a competency with one ER and no other ratings to trigger graduation', () => {
-        loadTeacherDashboard('SS/group:class_of_2020');
+        loadDashboard('SS/group:class_of_2020');
 
         let competency = 30; // SS.2
         let skill = 166; // SS.2.4
@@ -36,7 +36,7 @@ describe('CBL / Progress / Overrides', () => {
     });
 
     it('Override all skills in a competency with multiple ER and no other ratings to trigger graduation', () => {
-        loadTeacherDashboard('SS/group:class_of_2020');
+        loadDashboard('SS/group:class_of_2020');
 
         let competency = 29; // SS.1
         let skill = 162; // SS.1.5
@@ -55,7 +55,7 @@ describe('CBL / Progress / Overrides', () => {
     });
 
     it('Override one skill in a competency with one ER and one rating should have no impact', () => {
-        loadTeacherDashboard('SS/group:class_of_2020');
+        loadDashboard('SS/group:class_of_2020');
 
         let competency = 30; // SS.2
         let skill = 165; // SS.2.3
@@ -85,7 +85,7 @@ describe('CBL / Progress / Overrides', () => {
     });
 
     it('Override skill with multiple ERs and one rating.', () => {
-        loadTeacherDashboard('SS/group:class_of_2020');
+        loadDashboard('SS/group:class_of_2020');
 
         let competency = 29; // SS.1
         let skill = 160; // SS.1.3
@@ -115,7 +115,7 @@ describe('CBL / Progress / Overrides', () => {
     });
 
     it('Submit override resulting in graduation.', () => {
-        loadTeacherDashboard('SS/group:class_of_2020');
+        loadDashboard('SS/group:class_of_2020');
 
         let competency = 31; // SS.3
         let skill = 168;    // SS.3.2
@@ -134,7 +134,7 @@ describe('CBL / Progress / Overrides', () => {
     });
 
     it('Override a skill with an M rating and one white box.', () => {
-        loadTeacherDashboard('SS/group:class_of_2020');
+        loadDashboard('SS/group:class_of_2020');
 
         let competency = 32; // SS.4
         let skill = 169; // SS.4.1
@@ -153,7 +153,7 @@ describe('CBL / Progress / Overrides', () => {
     });
 
     it('Override for all skills where one set of ERs has all Ms.', () => {
-        loadTeacherDashboard('SS/group:class_of_2020');
+        loadDashboard('SS/group:class_of_2020');
 
         let competency = 32; // SS.4
         let skill = 170; // SS.4.2
@@ -172,7 +172,7 @@ describe('CBL / Progress / Overrides', () => {
     });
 
     it('Submit a rating for a skill with an override.', () => {
-        loadTeacherDashboard('ELA/group:class_of_2020');
+        loadDashboard('ELA/group:class_of_2020');
 
         let competency = 6; // ELA.6
         let skill = 28; // ELA.6.1
@@ -269,7 +269,7 @@ describe('CBL / Progress / Overrides', () => {
     });
 
     // TODO: taking this function from teacher-dashboard.js ... unify?
-    function loadTeacherDashboard(hashPath) {
+    function loadDashboard(hashPath) {
         // open student demonstrations dashboard
         cy.visit(`/cbl/dashboards/demonstrations/teacher${hashPath ? `#${hashPath}` : ''}`);
 

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -298,7 +298,6 @@ describe('CBL / Progress / Overrides', () => {
 
         // click cell for given skill/student
         cy.get('.cbl-grid-main .cbl-grid-skills-row[data-competency="'+competency+'"]')
-            .should('have.length', 1)
             .should('have.class', 'is-expanded')
             .find('.cbl-grid-skill-row[data-skill="'+skill+'"] .cbl-grid-demos-cell[data-student="'+student+'"]')
                 .click();

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -290,22 +290,18 @@ describe('CBL / Progress / Overrides', () => {
             .contains('.slate-placeholder', 'Select a list of students and a content area to load progress dashboard');
     };
 
-    function overrideSkillExpandcompetency(competency, skill, student) {
+    function overrideSkill(competency, skill, student) {
         // expand competency
         cy.get('.cbl-grid-progress-row[data-competency="'+competency+'"] .cbl-grid-competency-name')
             .should('have.length', 1)
             .click();
-    };
 
-    function overrideSkillClickCell(competency, skill, student) {
         // click cell for given skill/student
         cy.get('.cbl-grid-main .cbl-grid-skills-row[data-competency="'+competency+'"]')
             .should('have.class', 'is-expanded')
             .find('.cbl-grid-skill-row[data-skill="'+skill+'"] .cbl-grid-demos-cell[data-student="'+student+'"]')
                 .click();
-    };
 
-    function overrideSkillHistoryWindow(competency, skill, student) {
         // wait for history window to transition open
         cy.extGet('slate-window title[text="Skill History"]')
             .should('not.have.class', 'x-hidden-clip')
@@ -315,9 +311,7 @@ describe('CBL / Progress / Overrides', () => {
                     .should('have.length', 1)
                     .click();
             });
-    };
 
-    function overrideSkillOverrideWindow(competency, skill, student) {
         // wait for override window to transition open
         cy.extGet('slate-window title[text="Override Standard"]')
             .should('not.have.class', 'x-hidden-clip')
@@ -330,10 +324,9 @@ describe('CBL / Progress / Overrides', () => {
                     .should('have.length', 1)
                     .click();
             });
-        cy.wait('@saveDemonstration');
-    };
 
-    function overrideSkillCloseHistory(competency, skill, student) {
+        cy.wait('@saveDemonstration');
+
         // close the history window
         cy.extGet('slate-window title[text="Skill History"]')
             .should('have.length', 1)
@@ -345,62 +338,6 @@ describe('CBL / Progress / Overrides', () => {
             });
 
         cy.wait('@getDemonstrationSkills');
-    };
-
-    function overrideSkill(competency, skill, student) {
-        // expand competency
-        // cy.get('.cbl-grid-progress-row[data-competency="'+competency+'"] .cbl-grid-competency-name')
-        //     .should('have.length', 1)
-        //     .click();
-        overrideSkillExpandcompetency(competency, skill, student);
-
-        // click cell for given skill/student
-        // cy.get('.cbl-grid-main .cbl-grid-skills-row[data-competency="'+competency+'"]')
-        //     .should('have.class', 'is-expanded')
-        //     .find('.cbl-grid-skill-row[data-skill="'+skill+'"] .cbl-grid-demos-cell[data-student="'+student+'"]')
-        //         .click();
-        overrideSkillClickCell(competency, skill, student)
-
-        // wait for window to transition open
-        // cy.extGet('slate-window title[text="Skill History"]')
-        //     .should('not.have.class', 'x-hidden-clip')
-        //     .within(($window) => {
-        //         cy.extGet('button[text="Override"]')
-        //             .should('exist')
-        //             .click();
-        //     });
-        overrideSkillHistoryWindow(competency, skill, student)
-
-        // wait for window to transition open
-        // cy.extGet('slate-window title[text="Override Standard"]')
-        //     .should('have.length', 1)
-        //     .should('not.have.class', 'x-hidden-clip')
-        //     .within(($window) => {
-        //         cy.extGet('slate-cbl-demonstrations-overrideform textarea[name="Comments"]')
-        //             .type('Test Override');
-
-        //         cy.extGet('button[text="Submit Override"]')
-        //             .should('exist')
-        //             .click();
-        //     });
-
-        // cy.wait('@saveDemonstration');
-        overrideSkillOverrideWindow(competency, skill, student);
-
-
-
-        // close the window
-        // cy.extGet('slate-window title[text="Skill History"]')
-        //     .should('have.length', 1)
-        //     .should('not.have.class', 'x-hidden-clip')
-        //     .within(($window) => {
-        //         cy.extGet('tool[type="close"]')
-        //             .should('exist')
-        //             .click();
-        //     });
-
-        // cy.wait('@getDemonstrationSkills');
-        overrideSkillCloseHistory(competency, skill, student)
     };
 
     // Todo: this function from teacher-submit.js... potential for unification

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -311,9 +311,40 @@ describe('CBL / Progress / Overrides', () => {
             .should('not.have.class', 'x-hidden-clip')
             .within(($window) => {
                 cy.extGet('button[text="Override"]')
+                    // .should('exist')
+                    .should('have.length', 1)
+                    .click();
+            });
+    };
+
+    function overrideSkillOverrideWindow(competency, skill, student) {
+        // wait for override window to transition open
+        cy.extGet('slate-window title[text="Override Standard"]')
+            .should('not.have.class', 'x-hidden-clip')
+            .within(($window) => {
+                cy.extGet('slate-cbl-demonstrations-overrideform textarea[name="Comments"]')
+                    .type('Test Override');
+
+                cy.extGet('button[text="Submit Override"]')
+                    //.should('exist')
+                    .should('have.length', 1)
+                    .click();
+            });
+        cy.wait('@saveDemonstration');
+    };
+
+    function overrideSkillCloseHistory(competency, skill, student) {
+        // close the history window
+        cy.extGet('slate-window title[text="Skill History"]')
+            .should('have.length', 1)
+            .should('not.have.class', 'x-hidden-clip')
+            .within(($window) => {
+                cy.extGet('tool[type="close"]')
                     .should('exist')
                     .click();
             });
+
+        cy.wait('@getDemonstrationSkills');
     };
 
     function overrideSkill(competency, skill, student) {
@@ -341,31 +372,35 @@ describe('CBL / Progress / Overrides', () => {
         overrideSkillHistoryWindow(competency, skill, student)
 
         // wait for window to transition open
-        cy.extGet('slate-window title[text="Override Standard"]')
-            .should('have.length', 1)
-            .should('not.have.class', 'x-hidden-clip')
-            .within(($window) => {
-                cy.extGet('slate-cbl-demonstrations-overrideform textarea[name="Comments"]')
-                    .type('Test Override');
+        // cy.extGet('slate-window title[text="Override Standard"]')
+        //     .should('have.length', 1)
+        //     .should('not.have.class', 'x-hidden-clip')
+        //     .within(($window) => {
+        //         cy.extGet('slate-cbl-demonstrations-overrideform textarea[name="Comments"]')
+        //             .type('Test Override');
 
-                cy.extGet('button[text="Submit Override"]')
-                    .should('exist')
-                    .click();
-            });
+        //         cy.extGet('button[text="Submit Override"]')
+        //             .should('exist')
+        //             .click();
+        //     });
 
-        cy.wait('@saveDemonstration');
+        // cy.wait('@saveDemonstration');
+        overrideSkillOverrideWindow(competency, skill, student);
+
+
 
         // close the window
-        cy.extGet('slate-window title[text="Skill History"]')
-            .should('have.length', 1)
-            .should('not.have.class', 'x-hidden-clip')
-            .within(($window) => {
-                cy.extGet('tool[type="close"]')
-                    .should('exist')
-                    .click();
-            });
+        // cy.extGet('slate-window title[text="Skill History"]')
+        //     .should('have.length', 1)
+        //     .should('not.have.class', 'x-hidden-clip')
+        //     .within(($window) => {
+        //         cy.extGet('tool[type="close"]')
+        //             .should('exist')
+        //             .click();
+        //     });
 
-        cy.wait('@getDemonstrationSkills');
+        // cy.wait('@getDemonstrationSkills');
+        overrideSkillCloseHistory(competency, skill, student)
     };
 
     // Todo: this function from teacher-submit.js... potential for unification

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -17,7 +17,7 @@ describe('CBL / Progress / Overrides', () => {
     });
 
     it('Override all skills in a competency with one ER and no other ratings to trigger graduation', () => {
-        loadDashboard('SS/group:class_of_2020');
+        loadDashboard('SS', 'group:class_of_2020');
 
         const competency = 30; // SS.2
         const skill = 166; // SS.2.4
@@ -36,7 +36,7 @@ describe('CBL / Progress / Overrides', () => {
     });
 
     it('Override all skills in a competency with multiple ER and no other ratings to trigger graduation', () => {
-        loadDashboard('SS/group:class_of_2020');
+        loadDashboard('SS', 'group:class_of_2020');
 
         let competency = 29; // SS.1
         let skill = 162; // SS.1.5
@@ -55,7 +55,7 @@ describe('CBL / Progress / Overrides', () => {
     });
 
     it('Override one skill in a competency with one ER and one rating should have no impact', () => {
-        loadDashboard('SS/group:class_of_2020');
+        loadDashboard('SS', 'group:class_of_2020');
 
         let competency = 30; // SS.2
         let skill = 165; // SS.2.3
@@ -87,7 +87,7 @@ describe('CBL / Progress / Overrides', () => {
     });
 
     it('Override skill with multiple ERs and one rating.', () => {
-        loadDashboard('SS/group:class_of_2020');
+        loadDashboard('SS', 'group:class_of_2020');
 
         let competency = 29; // SS.1
         let skill = 160; // SS.1.3
@@ -119,7 +119,7 @@ describe('CBL / Progress / Overrides', () => {
     });
 
     it('Submit override resulting in graduation.', () => {
-        loadDashboard('SS/group:class_of_2020');
+        loadDashboard('SS', 'group:class_of_2020');
 
         let competency = 31; // SS.3
         let skill = 168;    // SS.3.2
@@ -138,7 +138,7 @@ describe('CBL / Progress / Overrides', () => {
     });
 
     it('Override a skill with an M rating and one white box.', () => {
-        loadDashboard('SS/group:class_of_2020');
+        loadDashboard('SS', 'group:class_of_2020');
 
         let competency = 32; // SS.4
         let skill = 169; // SS.4.1
@@ -157,7 +157,7 @@ describe('CBL / Progress / Overrides', () => {
     });
 
     it('Override for all skills where one set of ERs has all Ms.', () => {
-        loadDashboard('SS/group:class_of_2020');
+        loadDashboard('SS', 'group:class_of_2020');
 
         let competency = 32; // SS.4
         let skill = 170; // SS.4.2
@@ -176,7 +176,7 @@ describe('CBL / Progress / Overrides', () => {
     });
 
     it('Submit a rating for a skill with an override.', () => {
-        loadDashboard('ELA/group:class_of_2020');
+        loadDashboard('ELA', 'group:class_of_2020');
 
         let competency = 6; // ELA.6
         let skill = 28; // ELA.6.1
@@ -273,21 +273,30 @@ describe('CBL / Progress / Overrides', () => {
 
     });
 
-    // Todo: this function from teacher-dashboard.js... potential for unification
-    function loadDashboard(hashPath) {
+    function loadDashboard(competencyArea, studentsList) {
         // open student demonstrations dashboard
-        cy.visit(`/cbl/dashboards/demonstrations/teacher${hashPath ? `#${hashPath}` : ''}`);
+        cy.visit(`/cbl/dashboards/demonstrations/teacher#${competencyArea}/${studentsList}`);
 
         // ensure bootstrap data is loaded
         cy.wait('@getBootstrapData');
         cy.get('@getBootstrapData.all').should('have.length', 1);
 
         // verify teacher redirect
-        cy.location('hash').should('eq', hashPath ? `#${hashPath}` : '#_');
+        cy.location('hash').should('eq', `#${competencyArea}/${studentsList}`);
 
-        // verify placeholder
+        // ensure student competencies are loaded
+        cy.wait('@getStudentCompetencies');
+        cy.get('@getStudentCompetencies.all').should('have.length', 1);
+
+        // verify placeholder is gone
         cy.extGet('slate-demonstrations-teacher-dashboard')
-            .contains('.slate-placeholder', 'Select a list of students and a content area to load progress dashboard');
+            .find('.slate-placeholder')
+                .should('not.be.visible');
+
+        // verify competencies loaded
+        cy.extGet('slate-demonstrations-teacher-dashboard')
+            .find('.cbl-grid-competency-name')
+                .should('have.length.greaterThan', 0);
     };
 
     function overrideSkill(competency, skill, student) {

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -305,6 +305,7 @@ describe('CBL / Progress / Overrides', () => {
 
         // wait for window to transition open
         cy.extGet('slate-window title[text="Skill History"]')
+            .should('have.length', 1)
             .should('not.have.class', 'x-hidden-clip')
             .within(($window) => {
                 cy.extGet('button[text="Override"]')
@@ -314,6 +315,7 @@ describe('CBL / Progress / Overrides', () => {
 
         // wait for window to transition open
         cy.extGet('slate-window title[text="Override Standard"]')
+            .should('have.length', 1)
             .should('not.have.class', 'x-hidden-clip')
             .within(($window) => {
                 cy.extGet('slate-cbl-demonstrations-overrideform textarea[name="Comments"]')
@@ -328,6 +330,7 @@ describe('CBL / Progress / Overrides', () => {
 
         // close the window
         cy.extGet('slate-window title[text="Skill History"]')
+            .should('have.length', 1)
             .should('not.have.class', 'x-hidden-clip')
             .within(($window) => {
                 cy.extGet('tool[type="close"]')

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -314,7 +314,6 @@ function overrideSkill(competency, skill, student) {
 
     // wait for history window to transition open
     cy.extGet('title[text="Skill History"] ^ slate-window')
-        .should('have.length', 1)
         .should('not.have.class', 'x-hidden-clip')
         .within(() => {
             cy.get('.x-btn-inner:contains("Override")')

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -307,6 +307,7 @@ function overrideSkill(competency, skill, student) {
 
     // click cell for given skill/student
     cy.get(`.cbl-grid-main .cbl-grid-skills-row[data-competency="${competency}"]`)
+        .should('have.length', 1)
         .should('have.class', 'is-expanded')
         .find(`.cbl-grid-skill-row[data-skill="${skill}"] .cbl-grid-demos-cell[data-student="${student}"]`)
             .click();

--- a/cypress/integration/cbl/progress/overrides.js
+++ b/cypress/integration/cbl/progress/overrides.js
@@ -195,7 +195,7 @@ describe('CBL / Progress / Overrides', () => {
                 .click();
 
         // wait for window to transition open
-        cy.extGet('slate-window title[text="Skill History"]')
+        cy.extGet('title[text="Skill History"] ^ slate-window')
             .should('not.have.class', 'x-hidden-clip')
             .within(($window) => {
                 cy.extGet('button[text="Submit Evidence"]')
@@ -204,7 +204,7 @@ describe('CBL / Progress / Overrides', () => {
             });
 
         // wait for window to transition open
-        cy.extGet('slate-window title[text="Submit Evidence"]')
+        cy.extGet('title[text="Submit Evidence"] ^ slate-window')
             .should('not.have.class', 'x-hidden-clip')
             .within(($window) => {
                 // TODO: select using combo rather than typing
@@ -235,7 +235,7 @@ describe('CBL / Progress / Overrides', () => {
             });
 
         // close the window
-        cy.extGet('slate-window title[text="Skill History"]')
+        cy.extGet('title[text="Skill History"] ^ slate-window')
             .should('not.have.class', 'x-hidden-clip')
             .within(($window) => {
                 cy.extGet('tool[type="close"]')
@@ -312,7 +312,7 @@ describe('CBL / Progress / Overrides', () => {
                 .click();
 
         // wait for history window to transition open
-        cy.extGet('slate-window title[text="Skill History"]')
+        cy.extGet('title[text="Skill History"] ^ slate-window')
             .should('not.have.class', 'x-hidden-clip')
             .within(($window) => {
                 cy.extGet('button[text="Override"]')
@@ -322,7 +322,7 @@ describe('CBL / Progress / Overrides', () => {
             });
 
         // wait for override window to transition open
-        cy.extGet('slate-window title[text="Override Standard"]')
+        cy.extGet('title[text="Override Standard"] ^ slate-window')
             .should('not.have.class', 'x-hidden-clip')
             .within(($window) => {
                 cy.extGet('slate-cbl-demonstrations-overrideform textarea[name="Comments"]')
@@ -337,7 +337,7 @@ describe('CBL / Progress / Overrides', () => {
         cy.wait('@saveDemonstration');
 
         // close the history window
-        cy.extGet('slate-window title[text="Skill History"]')
+        cy.extGet('title[text="Skill History"] ^ slate-window')
             .should('have.length', 1)
             .should('not.have.class', 'x-hidden-clip')
             .within(($window) => {

--- a/cypress/integration/cbl/progress/teacher-submit.js
+++ b/cypress/integration/cbl/progress/teacher-submit.js
@@ -1,3 +1,5 @@
+const { getSlidersRatingSelector } = require('../../../support/ratings.js')
+
 describe('CBL / Progress / Teacher Submit', () => {
 
     // load sample database before tests
@@ -211,21 +213,3 @@ describe('CBL / Progress / Teacher Submit', () => {
         });
     });
 });
-
-function getSlidersRatingSelector(sliders) {
-    const firstSlider = sliders[0];
-    const { minRating, maxRating } = firstSlider.getConfig();
-    const visibleRatings = Array.from({length: maxRating - minRating + 1 }, (_, i) => i + minRating)
-    const totalThumbs = visibleRatings.length;
-    const ratingWidth = firstSlider.innerEl.getWidth() / totalThumbs;
-
-    return (slider, rating) => {
-        const selectedRatingPos = visibleRatings.indexOf(rating);
-        cy.wrap(slider.innerEl.dom)
-            .click({
-                x: ratingWidth * (selectedRatingPos + 1),
-                y: 5,
-                force: true
-            });
-    };
-}

--- a/cypress/support/ratings.js
+++ b/cypress/support/ratings.js
@@ -1,0 +1,19 @@
+module.exports = {
+    getSlidersRatingSelector: (sliders) => {
+        const firstSlider = sliders[0];
+        const { minRating, maxRating } = firstSlider.getConfig();
+        const visibleRatings = Array.from({length: maxRating - minRating + 1 }, (_, i) => i + minRating)
+        const totalThumbs = visibleRatings.length;
+        const ratingWidth = firstSlider.innerEl.getWidth() / totalThumbs;
+
+        return (slider, rating) => {
+            const selectedRatingPos = visibleRatings.indexOf(rating);
+            cy.wrap(slider.innerEl.dom)
+                .click({
+                    x: ratingWidth * (selectedRatingPos + 1),
+                    y: 5,
+                    force: true
+                });
+        };
+    }
+};


### PR DESCRIPTION
Closes: SCHOOL-125

- [X] Add fixture test cases for override baselines
- [x] Add test suite for overrides

Note on tests:  You may want me to move these tests to existing files.  There are 3 functions in this file.  One, just a simple loadDashboard() is from teacher-dashboard.js, another is the getSlidersRatingSelector() from teacher-submit.js and a third overrideSkill() that is new. The last test is the only test that uses getSlidersRatingSelector() and it does not use overrideSkill().  I think a potential way to split these up is to put the first 7 tests along with the overrideSkill() function into teacher-dashboard.js and move the last test into teacher-submit.js. 