### PR TITLE
feat: hide removed attachments from student views [SCHOOL-200]

### DIFF
--- a/sencha-workspace/SlateTasksStudent/app/controller/Tasks.js
+++ b/sencha-workspace/SlateTasksStudent/app/controller/Tasks.js
@@ -71,7 +71,8 @@ Ext.define('SlateTasksStudent.controller.Tasks', {
             minHeight: 200,
 
             mainView: {
-                xtype: 'slate-cbl-tasks-studenttaskform'
+                xtype: 'slate-cbl-tasks-studenttaskform',
+                displayRemovedTasks: false
             }
         },
         formPanel: 'slate-cbl-tasks-studenttaskform',

--- a/sencha-workspace/packages/slate-cbl/src/field/attachments/Field.js
+++ b/sencha-workspace/packages/slate-cbl/src/field/attachments/Field.js
@@ -175,14 +175,15 @@ Ext.define('Slate.cbl.field.attachments.Field', {
         return normalValue;
     },
 
-    filterValue: function(value) {
+    filterRemovedItems: function(value) {
         var me = this,
+            displayRemoved = me.getDisplayRemoved(),
             filteredValue = [],
             length = value ? value.length : 0,
             i = 0;
 
         for (; i < length; i++) {
-            if (value[i].Status.toLowerCase() !== 'removed') {
+            if (displayRemoved || value[i].Status.toLowerCase() !== 'removed') {
                 filteredValue.push(value[i]);
             }
         }
@@ -197,9 +198,7 @@ Ext.define('Slate.cbl.field.attachments.Field', {
             i = 0, length, itemValue, itemClass, Attachment, attachmentItem;
 
         // filter out items marked as 'removed' if applicable
-        if (me.displayRemoved === false) {
-            value = me.filterValue(value);
-        }
+        value = me.filterRemovedItems(value);
 
         // clone value to normalized array
         value = me.normalizeValue(value);

--- a/sencha-workspace/packages/slate-cbl/src/field/attachments/Field.js
+++ b/sencha-workspace/packages/slate-cbl/src/field/attachments/Field.js
@@ -24,7 +24,8 @@ Ext.define('Slate.cbl.field.attachments.Field', {
         ],
         toolbar: true,
 
-        fieldLabel: 'Attachments'
+        fieldLabel: 'Attachments',
+        displayRemoved: true
     },
 
 
@@ -174,12 +175,31 @@ Ext.define('Slate.cbl.field.attachments.Field', {
         return normalValue;
     },
 
+    filterValue: function(value) {
+        var me = this,
+            filteredValue = [],
+            length = value ? value.length : 0,
+            i = 0;
+
+        for (; i < length; i++) {
+            if (value[i].Status.toLowerCase() !== 'removed') {
+                filteredValue.push(value[i]);
+            }
+        }
+
+        return filteredValue;
+    },
+
     setValue: function(value) {
         var me = this,
             listCt = me.listCt,
             valueItemsMap = me.valueItemsMap = {},
-            length = value ? value.length : 0,
-            i = 0, itemValue, itemClass, Attachment, attachmentItem;
+            i = 0, length, itemValue, itemClass, Attachment, attachmentItem;
+
+        // filter out items marked as 'removed' if applicable
+        if (me.displayRemoved === false) {
+            value = me.filterValue(value);
+        }
 
         // clone value to normalized array
         value = me.normalizeValue(value);
@@ -190,6 +210,8 @@ Ext.define('Slate.cbl.field.attachments.Field', {
         Ext.suspendLayouts();
         ++me.suspendCheckChange;
         listCt.removeAll();
+
+        length = value ? value.length : 0;
 
         for (; i < length; i++) {
             itemValue = value[i];

--- a/sencha-workspace/packages/slate-cbl/src/view/tasks/StudentTaskForm.js
+++ b/sencha-workspace/packages/slate-cbl/src/view/tasks/StudentTaskForm.js
@@ -62,6 +62,7 @@ Ext.define('Slate.cbl.view.tasks.StudentTaskForm', function() {
 
         config: {
             studentTask: null,
+            displayRemovedTasks: true,
 
             statusField: {
                 merge: mergeFn,
@@ -524,7 +525,10 @@ Ext.define('Slate.cbl.view.tasks.StudentTaskForm', function() {
 
         // component lifecycle
         initItems: function() {
-            var me = this;
+            var me = this,
+                taskAttachmentsField = me.getTaskAttachmentsField();
+
+            taskAttachmentsField.setDisplayRemoved(me.getDisplayRemovedTasks());
 
             me.callParent();
 
@@ -575,7 +579,7 @@ Ext.define('Slate.cbl.view.tasks.StudentTaskForm', function() {
                         me.getExpirationDateOverrideField()
                     ]
                 },
-                me.getTaskAttachmentsField(),
+                taskAttachmentsField,
                 me.getRatingsField(),
                 me.getAttachmentsField(),
                 me.getSubmissionsField(),

--- a/sencha-workspace/packages/slate-cbl/src/view/tasks/StudentTaskForm.js
+++ b/sencha-workspace/packages/slate-cbl/src/view/tasks/StudentTaskForm.js
@@ -522,13 +522,14 @@ Ext.define('Slate.cbl.view.tasks.StudentTaskForm', function() {
         applySaveBtn: applyFn,
         applySubmitBtn: applyFn,
 
+        updateDisplayRemovedTasks(displayRemovedTasks) {
+          this.getTaskAttachmentsField().setDisplayRemoved(displayRemovedTasks);
+        },
+
 
         // component lifecycle
         initItems: function() {
-            var me = this,
-                taskAttachmentsField = me.getTaskAttachmentsField();
-
-            taskAttachmentsField.setDisplayRemoved(me.getDisplayRemovedTasks());
+            var me = this;
 
             me.callParent();
 
@@ -579,7 +580,7 @@ Ext.define('Slate.cbl.view.tasks.StudentTaskForm', function() {
                         me.getExpirationDateOverrideField()
                     ]
                 },
-                taskAttachmentsField,
+                me.getTaskAttachmentsField(),
                 me.getRatingsField(),
                 me.getAttachmentsField(),
                 me.getSubmissionsField(),


### PR DESCRIPTION
This PR will leave removed tasks visible and revertable in the task edit form, but hide them in the studenttask window entirely