### PR TITLE
feat: enable administrators to change demoskill target levels

### DIFF
--- a/php-classes/Slate/CBL/Demonstrations/DemonstrationSkill.php
+++ b/php-classes/Slate/CBL/Demonstrations/DemonstrationSkill.php
@@ -2,12 +2,14 @@
 
 namespace Slate\CBL\Demonstrations;
 
+use Emergence\People\IPerson;
+
 use Slate\CBL\Skill;
 use Slate\CBL\StudentCompetency;
 
 class DemonstrationSkill extends \VersionedRecord
 {
-    public static $allowTargetLevelChanges = false;
+    public static $allowTargetLevelChanges = 'Administrator';
 
     // ActiveRecord configuration
     public static $tableName = 'cbl_demonstration_skills';
@@ -86,7 +88,7 @@ class DemonstrationSkill extends \VersionedRecord
         }
 
         // target level can only be set on new records
-        if (!static::$allowTargetLevelChanges && !$this->isPhantom && $this->isFieldDirty('TargetLevel')) {
+        if (!$this->isPhantom && $this->isFieldDirty('TargetLevel') && !$this->userCanChangeLevel()) {
             $this->_validator->addError('TargetLevel', 'TargetLevel cannot be changed on existing records');
         }
 
@@ -103,4 +105,31 @@ class DemonstrationSkill extends \VersionedRecord
 
         return parent::save($deep);
     }
+
+    public function getAvailableActions(IPerson $User = null)
+    {
+        $User = $User ?: $this->getUserFromEnvironment();
+
+        $actions = parent::getAvailableActions($User);
+
+        $actions['change-level'] = $this->userCanChangeLevel($User);
+
+        return $actions;
+    }
+
+    public function userCanChangeLevel(IPerson $User = null)
+    {
+        if (static::$allowTargetLevelChanges === true) {
+            return true;
+        }
+
+        if (static::$allowTargetLevelChanges === false) {
+            return false;
+        }
+
+        $User = $User ?: $this->getUserFromEnvironment();
+
+        return $User && $User->hasAccountLevel(static::$allowTargetLevelChanges);
+    }
+
 }


### PR DESCRIPTION
Enables administrators to change `TargetLevel` on existing `DemonstrationSkill` records where previously it was entirely forbidden.

To verify, login as an admin and then:

```javascript
fetch('/cbl/demonstration-skills/save', {
  method: 'POST',
  credentials: 'include',
  headers: {
    accept: 'application/json',
    'content-type': 'application/json'
  },
  body: JSON.stringify({
    data: [
      { ID: 266, TargetLevel: 9 }
    ]
  })
}).then((response) => response.json())
  .then((data) => {
    console.log('Success:', data);
  })
  .catch((error) => {
    console.error('Error:', error);
  })
```