### PR TITLE
feat: Filter unshared tasks out of clone list and task library [SCHOOL-202, SCHOOL-208]

### DIFF
--- a/cypress/integration/cbl/admin/tasks-manager.js
+++ b/cypress/integration/cbl/admin/tasks-manager.js
@@ -216,4 +216,55 @@ describe('CBL / Admin / Tasks Manager', () => {
             .should('exist');
     });
 
+    it('Verify shared/unshared filtering in clone field', () => {
+
+        // open student demonstrations dashboard
+        cy.visit('/cbl/dashboards/tasks/manager');
+
+        // verify app loaded
+        cy.extGet('slate-tasks-manager')
+            .should('exist')
+            .contains('.slate-apptitle', 'Task Library');
+
+        // wait for data load
+        cy.wait('@tasksData');
+
+        // click create button
+        cy.extGet('slate-tasks-manager-appheader button[action=create]')
+            .click();
+
+        // wait for window to transition open
+        cy.extGet('slate-window')
+            .should('not.have.class', 'x-hidden-clip')
+            .within(() => {
+
+                // click cloned task selector
+                cy.extGet('slate-cbl-taskselector[name=ClonedTaskID]')
+                    .should('exist')
+                    .within(() => {
+
+                        cy.root()
+                            .get('.x-form-arrow-trigger')
+                            .click()
+
+                    });
+
+                // wait for options to load
+                cy.wait('@tasksData');
+
+                // verify shared task exists in picker dropdown
+                cy.extGet('slate-cbl-taskselector[name=ClonedTaskID]', { component: true })
+                    .then(selector => selector.getPicker().el.dom)
+                    .contains('.x-boundlist-item', 'A Shared Task')
+                    .should('exist');
+
+                // verify unshared task does not exist in picker dropdown
+                cy.extGet('slate-cbl-taskselector[name=ClonedTaskID]', { component: true })
+                    .then(selector => selector.getPicker().el.dom)
+                    .contains('.x-boundlist-item', 'An UnShared Task')
+                    .should('not.exist');
+            });
+
+    });
+
 });

--- a/cypress/integration/cbl/admin/tasks-manager.js
+++ b/cypress/integration/cbl/admin/tasks-manager.js
@@ -71,6 +71,17 @@ describe('CBL / Admin / Tasks Manager', () => {
         // wait for data load
         cy.wait('@tasksData');
 
+        // open options menu
+        cy.extGet('slate-tasks-manager-grid button[action=settings]')
+            .click();
+
+        // check 'include unshared' option
+        cy.extGet('slate-tasks-manager-grid menucheckitem[name=include-unshared]')
+            .click();
+
+        // wait for data load after option change
+        cy.wait('@tasksData');
+
         // find and click created task
         cy.extGet('slate-tasks-manager')
             .contains('.x-grid-cell-inner', 'Created Test Task Title')
@@ -84,6 +95,7 @@ describe('CBL / Admin / Tasks Manager', () => {
         cy.extGet('slate-window')
             .should('not.have.class', 'x-hidden-clip')
             .within(() => {
+
                 cy.root()
                     .contains('.x-title-text', 'Edit Task');
 
@@ -129,6 +141,17 @@ describe('CBL / Admin / Tasks Manager', () => {
             .contains('.slate-apptitle', 'Task Library');
 
         // wait for data load
+        cy.wait('@tasksData');
+
+        // open options menu
+        cy.extGet('slate-tasks-manager-grid button[action=settings]')
+            .click();
+
+        // check 'include unshared' option
+        cy.extGet('slate-tasks-manager-grid menucheckitem[name=include-unshared]')
+            .click();
+
+        // wait for data load after option change
         cy.wait('@tasksData');
 
         // find and click updated task

--- a/cypress/integration/cbl/admin/tasks-manager.js
+++ b/cypress/integration/cbl/admin/tasks-manager.js
@@ -71,17 +71,6 @@ describe('CBL / Admin / Tasks Manager', () => {
         // wait for data load
         cy.wait('@tasksData');
 
-        // open options menu
-        cy.extGet('slate-tasks-manager-grid button[action=settings]')
-            .click();
-
-        // check 'include unshared' option
-        cy.extGet('slate-tasks-manager-grid menucheckitem[name=include-unshared]')
-            .click();
-
-        // wait for data load after option change
-        cy.wait('@tasksData');
-
         // find and click created task
         cy.extGet('slate-tasks-manager')
             .contains('.x-grid-cell-inner', 'Created Test Task Title')
@@ -141,17 +130,6 @@ describe('CBL / Admin / Tasks Manager', () => {
             .contains('.slate-apptitle', 'Task Library');
 
         // wait for data load
-        cy.wait('@tasksData');
-
-        // open options menu
-        cy.extGet('slate-tasks-manager-grid button[action=settings]')
-            .click();
-
-        // check 'include unshared' option
-        cy.extGet('slate-tasks-manager-grid menucheckitem[name=include-unshared]')
-            .click();
-
-        // wait for data load after option change
         cy.wait('@tasksData');
 
         // find and click updated task

--- a/cypress/integration/cbl/admin/tasks-manager.js
+++ b/cypress/integration/cbl/admin/tasks-manager.js
@@ -165,4 +165,55 @@ describe('CBL / Admin / Tasks Manager', () => {
             });
     });
 
+    it('Verify grid filtering for shared and unshared tasks', () => {
+
+        // open student demonstrations dashboard
+        cy.visit('/cbl/dashboards/tasks/manager');
+
+        // verify app loaded
+        cy.extGet('slate-tasks-manager')
+            .should('exist')
+            .contains('.slate-apptitle', 'Task Library');
+
+        // wait for data load
+        cy.wait('@tasksData');
+
+        // verify that shared task is present
+        cy.extGet('slate-tasks-manager')
+            .should('exist')
+            .contains('.x-grid-cell-inner', 'A Shared Task')
+            .should('exist');
+
+        // verify that the unshared task is not present
+        cy.extGet('slate-tasks-manager')
+            .should('exist')
+            .contains('.x-grid-cell-inner', 'An Unshared Task')
+            .should('not.exist');
+
+        // open options menu
+        cy.extGet('slate-tasks-manager-grid button[action=settings]')
+            .should('exist')
+            .click();
+
+        // check 'include unshared' option
+        cy.extGet('slate-tasks-manager-grid menucheckitem[name=include-unshared]')
+            .should('exist')
+            .click();
+
+        // wait for data load after option change
+        cy.wait('@tasksData');
+
+        // verify that shared task is present
+        cy.extGet('slate-tasks-manager')
+            .should('exist')
+            .contains('.x-grid-cell-inner', 'A Shared Task')
+            .should('exist');
+
+        // verify that the unshared task is present
+        cy.extGet('slate-tasks-manager')
+            .should('exist')
+            .contains('.x-grid-cell-inner', 'An Unshared Task')
+            .should('exist');
+    });
+
 });

--- a/fixtures/cbl_student_tasks.sql
+++ b/fixtures/cbl_student_tasks.sql
@@ -230,6 +230,8 @@ INSERT INTO `cbl_student_tasks` VALUES (208,'Slate\\CBL\\Tasks\\StudentTask','20
 INSERT INTO `cbl_student_tasks` VALUES (209,'Slate\\CBL\\Tasks\\StudentTask','2022-08-09 21:20:13',3,'2022-08-09 21:23:48',3,12,10,'completed',228,NULL,NULL);
 INSERT INTO `cbl_student_tasks` VALUES (210,'Slate\\CBL\\Tasks\\StudentTask','2022-08-09 21:20:21',3,NULL,NULL,13,10,'assigned',NULL,NULL,NULL);
 INSERT INTO `cbl_student_tasks` VALUES (211,'Slate\\CBL\\Tasks\\StudentTask','2022-08-09 21:22:53',3,NULL,NULL,14,10,'assigned',NULL,NULL,NULL);
+INSERT INTO `cbl_student_tasks` VALUES (212,'Slate\\CBL\\Tasks\\StudentTask','2022-10-28 16:16:28',3,NULL,NULL,47,4,'assigned',NULL,NULL,NULL);
+INSERT INTO `cbl_student_tasks` VALUES (213,'Slate\\CBL\\Tasks\\StudentTask','2022-10-28 16:16:28',3,NULL,NULL,47,6,'assigned',NULL,NULL,NULL);
 
 
 CREATE TABLE `history_cbl_student_tasks` (

--- a/fixtures/cbl_task_skills.sql
+++ b/fixtures/cbl_task_skills.sql
@@ -128,6 +128,10 @@ INSERT INTO `cbl_task_skills` VALUES (113,'Slate\\CBL\\Tasks\\TaskSkill','2021-0
 INSERT INTO `cbl_task_skills` VALUES (114,'Slate\\CBL\\Tasks\\TaskSkill','2021-05-29 14:14:45',5,NULL,NULL,45,38);
 INSERT INTO `cbl_task_skills` VALUES (115,'Slate\\CBL\\Tasks\\TaskSkill','2021-05-29 14:14:45',5,NULL,NULL,45,39);
 INSERT INTO `cbl_task_skills` VALUES (116,'Slate\\CBL\\Tasks\\TaskSkill','2021-05-29 14:14:45',5,NULL,NULL,45,119);
+INSERT INTO `cbl_task_skills` VALUES (117,'Slate\\CBL\\Tasks\\TaskSkill','2022-10-28 16:16:28',3,NULL,NULL,47,61);
+INSERT INTO `cbl_task_skills` VALUES (118,'Slate\\CBL\\Tasks\\TaskSkill','2022-10-28 16:16:28',3,NULL,NULL,47,62);
+INSERT INTO `cbl_task_skills` VALUES (119,'Slate\\CBL\\Tasks\\TaskSkill','2022-10-28 16:17:07',3,NULL,NULL,46,61);
+INSERT INTO `cbl_task_skills` VALUES (120,'Slate\\CBL\\Tasks\\TaskSkill','2022-10-28 16:17:07',3,NULL,NULL,46,62);
 
 
 CREATE TABLE `history_cbl_task_skills` (

--- a/fixtures/cbl_tasks.sql
+++ b/fixtures/cbl_tasks.sql
@@ -69,6 +69,8 @@ INSERT INTO `cbl_tasks` VALUES (42,'Slate\\CBL\\Tasks\\ExperienceTask','2021-05-
 INSERT INTO `cbl_tasks` VALUES (43,'Slate\\CBL\\Tasks\\ExperienceTask','2021-05-29 14:11:20',5,NULL,NULL,7,'M.6 Step.4: Formal Style','m.6_step.4--formal_style',39,NULL,NULL,'shared','Complete and submit the assessment.',NULL,NULL,'Studio');
 INSERT INTO `cbl_tasks` VALUES (44,'Slate\\CBL\\Tasks\\ExperienceTask','2021-05-29 14:12:54',5,NULL,NULL,7,'M.6 Step.5: Conclusion','m.6_step.5--conclusion',39,NULL,NULL,'shared','Complete and submit the assessment.',NULL,NULL,'Studio');
 INSERT INTO `cbl_tasks` VALUES (45,'Slate\\CBL\\Tasks\\ExperienceTask','2021-05-29 14:14:45',5,NULL,NULL,7,'Reflection: Who Gets a Vote','reflection--who_gets_a_vote',NULL,21,NULL,'shared','Complete the reflection google form.',NULL,NULL,'Studio');
+INSERT INTO `cbl_tasks` VALUES (46,'Slate\\CBL\\Tasks\\ExperienceTask','2022-10-28 16:13:22',3,'2022-10-28 16:17:07',3,0,'A Shared Task','a_shared_task',NULL,NULL,NULL,'shared','A shared task that will be used to test the filtering of shared and unshared tasks',NULL,NULL,'Studio');
+INSERT INTO `cbl_tasks` VALUES (47,'Slate\\CBL\\Tasks\\ExperienceTask','2022-10-28 16:16:28',3,NULL,NULL,1,'An Unshared Task','an_unshared_task',NULL,NULL,NULL,'private','An unshared task that will be used to test the filtering of shared and unshared tasks',NULL,NULL,'Studio');
 
 
 CREATE TABLE `history_cbl_tasks` (

--- a/php-classes/Slate/CBL/Tasks/TasksRequestHandler.php
+++ b/php-classes/Slate/CBL/Tasks/TasksRequestHandler.php
@@ -51,10 +51,10 @@ class TasksRequestHandler extends \RecordsRequestHandler
             }
 
             $includeUnshared = isset($_REQUEST['include_unshared']) && ($_REQUEST['include_unshared']=='true');
-            $sharedConditions = static::getSharedConditions($includeUnshared);
+            //$sharedConditions = static::getSharedConditions($includeUnshared);
 
-            if ($sharedConditions != false) {
-                $conditions[] = $sharedConditions;
+            if (!$includeUnshared) {
+                $conditions['Status'] = 'shared';
             }
         }
 
@@ -195,13 +195,6 @@ class TasksRequestHandler extends \RecordsRequestHandler
                     $GLOBALS['Session']->PersonID
                 );
             }
-        }
-    }
-
-    public static function getSharedConditions($includeShared) {
-        $recordClass = static::$recordClass;
-        if (!$includeShared) {
-            return $recordClass::getTableAlias().'.Status != "shared"';
         }
     }
 }

--- a/php-classes/Slate/CBL/Tasks/TasksRequestHandler.php
+++ b/php-classes/Slate/CBL/Tasks/TasksRequestHandler.php
@@ -51,7 +51,6 @@ class TasksRequestHandler extends \RecordsRequestHandler
             }
 
             $includeUnshared = isset($_REQUEST['include_unshared']) && ($_REQUEST['include_unshared']=='true');
-            //$sharedConditions = static::getSharedConditions($includeUnshared);
 
             if (!$includeUnshared) {
                 $conditions['Status'] = 'shared';

--- a/php-classes/Slate/CBL/Tasks/TasksRequestHandler.php
+++ b/php-classes/Slate/CBL/Tasks/TasksRequestHandler.php
@@ -49,6 +49,13 @@ class TasksRequestHandler extends \RecordsRequestHandler
             if ($archivedConditions != false) {
                 $conditions[] = $archivedConditions;
             }
+
+            $includeShared = isset($_REQUEST['include_shared']) && ($_REQUEST['include_shared']=='true');
+            $sharedConditions = static::getSharedConditions($includeShared);
+
+            if ($sharedConditions != false) {
+                $conditions[] = $sharedConditions;
+            }
         }
 
         return $conditions;
@@ -188,6 +195,13 @@ class TasksRequestHandler extends \RecordsRequestHandler
                     $GLOBALS['Session']->PersonID
                 );
             }
+        }
+    }
+
+    public static function getSharedConditions($includeShared) {
+        $recordClass = static::$recordClass;
+        if (!$includeShared) {
+            return $recordClass::getTableAlias().'.Status != "shared"';
         }
     }
 }

--- a/php-classes/Slate/CBL/Tasks/TasksRequestHandler.php
+++ b/php-classes/Slate/CBL/Tasks/TasksRequestHandler.php
@@ -50,8 +50,8 @@ class TasksRequestHandler extends \RecordsRequestHandler
                 $conditions[] = $archivedConditions;
             }
 
-            $includeShared = isset($_REQUEST['include_shared']) && ($_REQUEST['include_shared']=='true');
-            $sharedConditions = static::getSharedConditions($includeShared);
+            $includeUnshared = isset($_REQUEST['include_unshared']) && ($_REQUEST['include_unshared']=='true');
+            $sharedConditions = static::getSharedConditions($includeUnshared);
 
             if ($sharedConditions != false) {
                 $conditions[] = $sharedConditions;

--- a/sencha-workspace/SlateTasksManager/app/controller/Tasks.js
+++ b/sencha-workspace/SlateTasksManager/app/controller/Tasks.js
@@ -51,7 +51,7 @@ Ext.define('SlateTasksManager.controller.Tasks', {
         clearFiltersButton: 'slate-tasks-manager-grid button[action=clear-filters]',
 
         clonedTaskField: 'slate-cbl-tasks-taskform field[name=ClonedTaskID]',
-        sharedTaskCheckbox: 'slate-window checkboxfield[name=Status]',
+        sharedTaskCheckbox: 'slate-cbl-tasks-taskform ^ window checkboxfield[name=Status]',
 
         taskWindow: {
             autoCreate: true,

--- a/sencha-workspace/SlateTasksManager/app/controller/Tasks.js
+++ b/sencha-workspace/SlateTasksManager/app/controller/Tasks.js
@@ -102,8 +102,8 @@ Ext.define('SlateTasksManager.controller.Tasks', {
         'slate-tasks-manager-grid menucheckitem[name=include-archived]': {
             checkChange: 'onArchiveCheckboxClick'
         },
-        'slate-tasks-manager-grid menucheckitem[name=include-shared]': {
-            checkChange: 'onIncludeSharedCheckboxClick'
+        'slate-tasks-manager-grid menucheckitem[name=include-unshared]': {
+            checkChange: 'onIncludeUnsharedCheckboxClick'
         },
         'slate-cbl-tasks-taskform ^ window button[action=archive]' :{
             click: 'onArchiveClick'
@@ -158,10 +158,10 @@ Ext.define('SlateTasksManager.controller.Tasks', {
         tasksStore.load();
     },
 
-    onIncludeSharedCheckboxClick: function(checkbox) {
+    onIncludeUnsharedCheckboxClick: function(checkbox) {
         var tasksStore = this.getTasksStore();
 
-        tasksStore.getProxy().extraParams.include_shared = checkbox.checked;
+        tasksStore.getProxy().extraParams.include_unshared = checkbox.checked;
         tasksStore.load();
     },
 

--- a/sencha-workspace/SlateTasksManager/app/controller/Tasks.js
+++ b/sencha-workspace/SlateTasksManager/app/controller/Tasks.js
@@ -51,6 +51,7 @@ Ext.define('SlateTasksManager.controller.Tasks', {
         clearFiltersButton: 'slate-tasks-manager-grid button[action=clear-filters]',
 
         clonedTaskField: 'slate-cbl-tasks-taskform field[name=ClonedTaskID]',
+        sharedTaskCheckbox: 'slate-window checkboxfield[name=Status]',
 
         taskWindow: {
             autoCreate: true,
@@ -566,6 +567,7 @@ Ext.define('SlateTasksManager.controller.Tasks', {
                 SectionID: 0,
                 Status: 'shared'
             }, task || null));
+            me.getSharedTaskCheckbox().setDisabled(true);
         }
 
         taskWindow.animateTarget = animateTarget;

--- a/sencha-workspace/SlateTasksManager/app/controller/Tasks.js
+++ b/sencha-workspace/SlateTasksManager/app/controller/Tasks.js
@@ -102,6 +102,9 @@ Ext.define('SlateTasksManager.controller.Tasks', {
         'slate-tasks-manager-grid menucheckitem[name=include-archived]': {
             checkChange: 'onArchiveCheckboxClick'
         },
+        'slate-tasks-manager-grid menucheckitem[name=include-shared]': {
+            checkChange: 'onIncludeSharedCheckboxClick'
+        },
         'slate-cbl-tasks-taskform ^ window button[action=archive]' :{
             click: 'onArchiveClick'
         },
@@ -152,6 +155,13 @@ Ext.define('SlateTasksManager.controller.Tasks', {
         var tasksStore = this.getTasksStore();
 
         tasksStore.getProxy().extraParams.include_archived = checkbox.checked;
+        tasksStore.load();
+    },
+
+    onIncludeSharedCheckboxClick: function(checkbox) {
+        var tasksStore = this.getTasksStore();
+
+        tasksStore.getProxy().extraParams.include_shared = checkbox.checked;
         tasksStore.load();
     },
 

--- a/sencha-workspace/SlateTasksManager/app/controller/Tasks.js
+++ b/sencha-workspace/SlateTasksManager/app/controller/Tasks.js
@@ -562,6 +562,9 @@ Ext.define('SlateTasksManager.controller.Tasks', {
             }),
             taskEditor = taskWindow.getMainView();
 
+        // re-enable shared checkbox if it has been previously disabled during task creation
+        me.getSharedTaskCheckbox().setDisabled(false);
+
         if (!task || (typeof task == 'object' && !task.isModel)) {
             task = me.getTaskModel().create(Ext.apply({
                 SectionID: 0,

--- a/sencha-workspace/SlateTasksManager/app/controller/Tasks.js
+++ b/sencha-workspace/SlateTasksManager/app/controller/Tasks.js
@@ -155,15 +155,15 @@ Ext.define('SlateTasksManager.controller.Tasks', {
     onArchiveCheckboxClick: function(checkbox) {
         var tasksStore = this.getTasksStore();
 
-        tasksStore.getProxy().extraParams.include_archived = checkbox.checked;
-        tasksStore.load();
+        tasksStore.getProxy().setExtraParam('include_archived', checkbox.checked);
+        tasksStore.load({ page: 1 });
     },
 
     onIncludeUnsharedCheckboxClick: function(checkbox) {
         var tasksStore = this.getTasksStore();
 
-        tasksStore.getProxy().extraParams.include_unshared = checkbox.checked;
-        tasksStore.load();
+        tasksStore.getProxy().setExtraParam('include_unshared', checkbox.checked);
+        tasksStore.load({ page: 1 });
     },
 
     onGridFilterChange(store, filters) {

--- a/sencha-workspace/SlateTasksManager/app/view/TasksGrid.js
+++ b/sencha-workspace/SlateTasksManager/app/view/TasksGrid.js
@@ -42,10 +42,19 @@ Ext.define('SlateTasksManager.view.TasksGrid', {
               arrowVisible: false,
               arrowAlign: 'top',
               menu: {
+                  title: {
+                      text: 'Options',
+                      iconCls: 'x-fa fa-gear'
+                  },
                   items: [{
                       xtype: 'menucheckitem',
                       text: 'include archived',
                       name: 'include-archived',
+                      value: false,
+                  }, {
+                      xtype: 'menucheckitem',
+                      text: 'include shared',
+                      name: 'include-shared',
                       value: false,
                   }]
               }

--- a/sencha-workspace/SlateTasksManager/app/view/TasksGrid.js
+++ b/sencha-workspace/SlateTasksManager/app/view/TasksGrid.js
@@ -53,8 +53,8 @@ Ext.define('SlateTasksManager.view.TasksGrid', {
                       value: false,
                   }, {
                       xtype: 'menucheckitem',
-                      text: 'include shared',
-                      name: 'include-shared',
+                      text: 'include unshared',
+                      name: 'include-unshared',
                       value: false,
                   }]
               }

--- a/sencha-workspace/SlateTasksManager/app/view/TasksManager.scss
+++ b/sencha-workspace/SlateTasksManager/app/view/TasksManager.scss
@@ -1,3 +1,16 @@
 .x-btn-icon-el.x-tbar-loading {
     background-size: 98%;
 }
+
+.x-menu {
+    .x-title {
+        table-layout: auto;
+        background: #e9e9e9;
+        .x-title-icon {
+            color: #777;
+        }
+    }
+    .x-menu-item-text-default {
+        line-height: 26px;
+    }
+}


### PR DESCRIPTION
Closes: SCHOOL-202

The clone menu and task library both currently show all tasks regardless of whether they had their “shared” option checked or not.

Filter non-shared tasks out of both the clone menu and task library

Add fixture data as needed so we have a set of shared and non-shared tasks with corresponding titles, and extend existing automated tests for the teacher tasks dashboard and task library to verify that the clone task menu and the task library both exclude unshared tasks and include shared ones.

Bonus: add an “include unshared” option to the task library’s advanced menu. It is fine for any teacher with access to the task library to be able to browse unshared tasks.