### PR TITLE
fix(e2e): ensure filter menu out of way before opening task

### DIFF
--- a/cypress/integration/cbl/tasks/student-dashboard.js
+++ b/cypress/integration/cbl/tasks/student-dashboard.js
@@ -245,6 +245,9 @@ describe('CBL / Tasks / Student Dashboard: Workflows', () => {
             _deselectAllFilters();
             _selectFilter('Due Tasks', '.slate-tasktree-status-due, .slate-tasktree-status-late');
 
+            // close filter menu to prevent interference with opening task
+            _clickFilterButton();
+
             // open recently created task
             cy.extGet('slate-tasks-student-tasktree')
                 .find(`.slate-tasktree-item[data-id=${studentTaskId}]`)


### PR DESCRIPTION
Should help with a test we've seen failing a lot lately