### PR TITLE
replacing visibleLevels with a drilled prop instead of provide/inject

### DIFF
--- a/static-webapps/slate-portfolio-manager/src/components/AdvancedPortfolioSidebar.vue
+++ b/static-webapps/slate-portfolio-manager/src/components/AdvancedPortfolioSidebar.vue
@@ -54,6 +54,7 @@
           :demonstrations="demonstrations"
           :skills-by-i-d="skillsByID"
           :show-hidden-items="showHiddenItems"
+          :visible-levels="visibleLevels"
           @refetch="refetch"
         />
       </li>
@@ -62,7 +63,6 @@
 </template>
 
 <script>
-import { computed } from '@vue/reactivity';
 import { mapStores } from 'pinia';
 
 import Student from '@/models/Student';
@@ -75,15 +75,6 @@ import LevelPanel from './sidebar/LevelPanel.vue';
 export default {
   components: {
     LevelPanel,
-  },
-
-  provide() {
-    return {
-      visibleLevels: computed(() => {
-        const details = this.studentCompetencyDetails;
-        return details ? details.data.map((portfolio) => portfolio.Level) : [];
-      }),
-    };
   },
 
   props: {
@@ -99,6 +90,11 @@ export default {
 
   computed: {
     ...mapStores(useCompetency, useDemonstration, useStudentCompetency, useDemonstrationSkill),
+
+    visibleLevels() {
+      const details = this.studentCompetencyDetails;
+      return details ? details.data.map((portfolio) => portfolio.Level) : [];
+    },
 
     competencies() {
       const competencyArea = this.$route.query.area;

--- a/static-webapps/slate-portfolio-manager/src/components/sidebar/LevelPanel.vue
+++ b/static-webapps/slate-portfolio-manager/src/components/sidebar/LevelPanel.vue
@@ -57,6 +57,7 @@
         v-bind="skillDemo"
         :show-hidden-items="showHiddenItems"
         :level="portfolio.Level"
+        :visible-levels="visibleLevels"
         @refetch="$emit('refetch')"
       />
     </b-collapse>
@@ -76,6 +77,10 @@ export default {
   },
 
   props: {
+    visibleLevels: {
+      type: Array,
+      default: () => [],
+    },
     showHiddenItems: {
       type: Boolean,
       default: () => false,

--- a/static-webapps/slate-portfolio-manager/src/components/sidebar/SkillDemoCard.vue
+++ b/static-webapps/slate-portfolio-manager/src/components/sidebar/SkillDemoCard.vue
@@ -48,8 +48,11 @@ import useDemonstrationSkill from '@/store/useDemonstrationSkill';
 import useUi from '@/store/useUi';
 
 export default {
-  inject: ['visibleLevels'],
   props: {
+    visibleLevels: {
+      type: Array,
+      default: () => [],
+    },
     demo: {
       type: Object,
       default: () => ({}),
@@ -63,7 +66,7 @@ export default {
   computed: {
     ...mapStores(useDemonstrationSkill, useUi),
     targetLevels() {
-      const visibleLevels = this.visibleLevels.value.slice();
+      const visibleLevels = this.visibleLevels.slice();
       const higherLevels = visibleLevels.filter((l) => l > this.level);
       const lowerLevels = visibleLevels.filter((l) => l < this.level);
       const targetLevels = [];

--- a/static-webapps/slate-portfolio-manager/src/components/sidebar/SkillDemos.vue
+++ b/static-webapps/slate-portfolio-manager/src/components/sidebar/SkillDemos.vue
@@ -24,6 +24,7 @@
         :class="demo.class"
         :show-hidden-items="showHiddenItems"
         :level="level"
+        :visible-levels="visibleLevels"
         @refetch="$emit('refetch')"
       />
     </ol>
@@ -62,6 +63,10 @@ export default {
       default: () => [],
     },
     demonstrations: {
+      type: Array,
+      default: () => [],
+    },
+    visibleLevels: {
       type: Array,
       default: () => [],
     },


### PR DESCRIPTION
I was fairly sure I tested this, but apparently provide/inject is buggy in vue 2 so I had to drill a prop instead. 