### PR TITLE
feat: uncheck shared checkbox after cloning a task [SCHOOL-203]

### DIFF
--- a/sencha-workspace/SlateTasksTeacher/app/controller/Tasks.js
+++ b/sencha-workspace/SlateTasksTeacher/app/controller/Tasks.js
@@ -110,9 +110,10 @@ Ext.define('SlateTasksTeacher.controller.Tasks', {
         formPanel: 'slate-cbl-tasks-taskform',
         clonedTaskField: 'slate-cbl-tasks-taskform field[name=ClonedTaskID]',
         statusField: 'slate-cbl-tasks-taskform ^ window field[name=Status]',
-        submitBtn: 'slate-cbl-tasks-taskform ^ window button[action=submit]',
         archiveBtn: 'slate-cbl-tasks-taskform ^ window button[action=archive]',
-        unarchiveBtn: 'slate-cbl-tasks-taskform ^ window button[action=un-archive]'
+        unarchiveBtn: 'slate-cbl-tasks-taskform ^ window button[action=un-archive]',
+        sharedTaskCheckbox: 'slate-cbl-tasks-taskform ^ window checkboxfield[name=Status]',
+        submitBtn: 'slate-cbl-tasks-taskform ^ window button[action=submit]'
     },
 
 
@@ -239,7 +240,8 @@ Ext.define('SlateTasksTeacher.controller.Tasks', {
     },
 
     onClonedTaskSelect: function(clonedTaskField, clonedTask) {
-        var formPanel = this.getFormPanel(),
+        var me = this,
+            formPanel = me.getFormPanel(),
             form = formPanel.getForm(),
             fields = clonedTask.getFields(),
             fieldsLength = fields.length, fieldIndex = 0, field, fieldName, formField;
@@ -265,6 +267,7 @@ Ext.define('SlateTasksTeacher.controller.Tasks', {
                     }
                 }
 
+                me.getSharedTaskCheckbox().setValue(false);  // expressly uncheck after selecting to clone a task
                 formPanel.setLoading(false);
             },
             failure: function(savedTask, operation) {


### PR DESCRIPTION
Make sure that both in the teacher task dashboard and in the task library, that the “share” checkbox gets expressly unchecked after selecting to clone a task. Currently it my stay checked or unchecked based on its previous state

Notes:
     - this has been implemented when creating a task in the teacher task interface.
     - This is not possible when creating a task in the task library interface.  The check box must be checked (it is checked and disabled) or the user will be unable to create a new task.   Unshared tasks cannot be created unless they have an assigned section and there is no way to assign a section to a task when using the task form in the task library interface
     - This is inapplicable when editing tasks in both the teacher and the library interface because the clone field is not available when editing tasks