### PR TITLE
adding ability to delete portfolio

### DIFF
--- a/php-classes/Slate/CBL/StudentCompetenciesRequestHandler.php
+++ b/php-classes/Slate/CBL/StudentCompetenciesRequestHandler.php
@@ -105,4 +105,14 @@ class StudentCompetenciesRequestHandler extends RecordsRequestHandler
 
         return $conditions;
     }
+
+
+    protected static function onBeforeRecordDestroyed(ActiveRecord $StudentCompetency)
+    {
+        if (count($StudentCompetency->getDemonstrationsData()) > 0) {
+            return static::throwInvalidRequestError('Portfolios must be emptied before they are deleted');
+        }
+
+        return parent::onBeforeRecordDestroyed($StudentCompetency);
+    }
 }

--- a/static-webapps/slate-portfolio-manager/.eslintrc.js
+++ b/static-webapps/slate-portfolio-manager/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'vue',
   ],
   rules: {
+    'no-param-reassign': 0,
     'no-unused-vars': [
       'error',
       {

--- a/static-webapps/slate-portfolio-manager/package-lock.json
+++ b/static-webapps/slate-portfolio-manager/package-lock.json
@@ -22,6 +22,7 @@
         "date-fns": "^2.29.3",
         "local-storage-json": "^1.1.0",
         "lodash": "^4.17.21",
+        "mitt": "^3.0.0",
         "pinia": "^2.0.22",
         "vue": "^2.6.11",
         "vue-router": "^3.5.2"
@@ -10082,6 +10083,11 @@
       "engines": {
         "node": ">=4.0.0"
       }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
     },
     "node_modules/mixin-deep": {
       "version": "1.3.2",
@@ -24088,6 +24094,11 @@
         "stream-each": "^1.1.0",
         "through2": "^2.0.0"
       }
+    },
+    "mitt": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
     },
     "mixin-deep": {
       "version": "1.3.2",

--- a/static-webapps/slate-portfolio-manager/package.json
+++ b/static-webapps/slate-portfolio-manager/package.json
@@ -23,6 +23,7 @@
     "date-fns": "^2.29.3",
     "local-storage-json": "^1.1.0",
     "lodash": "^4.17.21",
+    "mitt": "^3.0.0",
     "pinia": "^2.0.22",
     "vue": "^2.6.11",
     "vue-router": "^3.5.2"

--- a/static-webapps/slate-portfolio-manager/src/components/AdvancedPortfolioSidebar.vue
+++ b/static-webapps/slate-portfolio-manager/src/components/AdvancedPortfolioSidebar.vue
@@ -55,7 +55,6 @@
           :skills-by-i-d="skillsByID"
           :show-hidden-items="showHiddenItems"
           :visible-levels="visibleLevels"
-          @refetch="refetch"
         />
       </li>
     </ol>
@@ -66,6 +65,7 @@
 import { mapStores } from 'pinia';
 
 import Student from '@/models/Student';
+import emitter from '@/store/emitter';
 import useCompetency from '@/store/useCompetency';
 import useDemonstrationSkill from '@/store/useDemonstrationSkill';
 import useStudentCompetency from '@/store/useStudentCompetency';
@@ -176,9 +176,21 @@ export default {
       return response && response.data;
     },
   },
+
+  mounted() {
+    emitter.on('update-store', this.updateStore);
+  },
+
+  unmounted() {
+    emitter.off('update-store', this.updateStore);
+  },
+
   methods: {
-    refetch() {
-      return this.studentCompetencyStore.refetch(this.studentCompetencyDetailsUrl);
+    updateStore(options) {
+      const { studentID, competencyID } = options;
+      if (studentID === this.selected.student.ID || competencyID === this.selected.competency.ID) {
+        this.studentCompetencyStore.refetch(this.studentCompetencyDetailsUrl);
+      }
     },
   },
 };

--- a/static-webapps/slate-portfolio-manager/src/components/sidebar/LevelPanel.vue
+++ b/static-webapps/slate-portfolio-manager/src/components/sidebar/LevelPanel.vue
@@ -183,7 +183,7 @@ export default {
     startDelete() {
       let body = `Are you sure you want to delete Year ${this.portfolio.Level}?`;
       body += ' This cannot be undone.';
-      const action = () => this.studentCompetencyStore.delete(this.portfolio.Level).then(
+      const action = () => this.studentCompetencyStore.delete(this.portfolio.ID).then(
         () => this.$emit('refetch'),
       );
       this.uiStore.confirm(body, action);

--- a/static-webapps/slate-portfolio-manager/src/components/sidebar/LevelPanel.vue
+++ b/static-webapps/slate-portfolio-manager/src/components/sidebar/LevelPanel.vue
@@ -58,7 +58,7 @@
         :show-hidden-items="showHiddenItems"
         :level="portfolio.Level"
         :visible-levels="visibleLevels"
-        @refetch="$emit('refetch')"
+        @refetch="refetch"
       />
       <div
         v-if="canDelete"
@@ -80,6 +80,8 @@ import { mapStores } from 'pinia';
 import SkillDemos from './SkillDemos.vue';
 import SkillProgress from './SkillProgress.vue';
 import StatFigure from './StatFigure.vue';
+
+import emitter from '@/store/emitter';
 import useStudentCompetency from '@/store/useStudentCompetency';
 import useUi from '@/store/useUi';
 
@@ -180,12 +182,14 @@ export default {
       // append it to the level color as a hex/255
       return `background-color: #${this.levelColor}${Math.round(alpha * 255).toString(16)}`;
     },
+    refetch() {
+      const { StudentID, CompetencyID } = this.portfolio;
+      emitter.emit('update-store', { StudentID, CompetencyID });
+    },
     startDelete() {
       let body = `Are you sure you want to delete Year ${this.portfolio.Level}?`;
       body += ' This cannot be undone.';
-      const action = () => this.studentCompetencyStore.delete(this.portfolio.ID).then(
-        () => this.$emit('refetch'),
-      );
+      const action = () => this.studentCompetencyStore.delete(this.portfolio.ID).then(this.refetch);
       this.uiStore.confirm(body, action);
     },
   },

--- a/static-webapps/slate-portfolio-manager/src/components/sidebar/LevelPanel.vue
+++ b/static-webapps/slate-portfolio-manager/src/components/sidebar/LevelPanel.vue
@@ -60,14 +60,28 @@
         :visible-levels="visibleLevels"
         @refetch="$emit('refetch')"
       />
+      <div
+        v-if="canDelete"
+        class="p-3 bg-cbl-level-10"
+      >
+        <button
+          class="btn btn-danger"
+          @click="startDelete"
+        >
+          Delete Porfolio
+        </button>
+      </div>
     </b-collapse>
   </div>
 </template>
 
 <script>
+import { mapStores } from 'pinia';
 import SkillDemos from './SkillDemos.vue';
 import SkillProgress from './SkillProgress.vue';
 import StatFigure from './StatFigure.vue';
+import useStudentCompetency from '@/store/useStudentCompetency';
+import useUi from '@/store/useUi';
 
 export default {
   components: {
@@ -100,6 +114,7 @@ export default {
   },
 
   computed: {
+    ...mapStores(useStudentCompetency, useUi),
     ready() {
       return this.demonstrations.length !== 0;
     },
@@ -152,6 +167,11 @@ export default {
       });
       return Object.values(out);
     },
+
+    canDelete() {
+      const nextLevel = this.visibleLevels.find((level) => level > this.portfolio.Level);
+      return this.preppedSkillDemos.length === 0 && !nextLevel;
+    },
   },
 
   methods: {
@@ -159,6 +179,14 @@ export default {
       // take alpha as decimal, e.g., .5 for 50%
       // append it to the level color as a hex/255
       return `background-color: #${this.levelColor}${Math.round(alpha * 255).toString(16)}`;
+    },
+    startDelete() {
+      let body = `Are you sure you want to delete Year ${this.portfolio.Level}?`;
+      body += ' This cannot be undone.';
+      const action = () => this.studentCompetencyStore.delete(this.portfolio.Level).then(
+        () => this.$emit('refetch'),
+      );
+      this.uiStore.confirm(body, action);
     },
   },
 };

--- a/static-webapps/slate-portfolio-manager/src/components/sidebar/SkillDemos.vue
+++ b/static-webapps/slate-portfolio-manager/src/components/sidebar/SkillDemos.vue
@@ -12,7 +12,7 @@
       style="gap: 0.25rem;"
     >
       <li
-        v-if="skillDemos.length == 0"
+        v-if="skillDemos.length === 0"
         class="text-black-50 font-italic m-0"
       >
         No demonstrations recorded

--- a/static-webapps/slate-portfolio-manager/src/store/defineRestStore.js
+++ b/static-webapps/slate-portfolio-manager/src/store/defineRestStore.js
@@ -97,6 +97,15 @@ export default ({
           return response;
         });
       },
+
+      delete(identifier) {
+        const url = makeUrl(`/${identifier}/delete`);
+        Vue.set(this.$state.loading, url, true);
+        return client.post(url).then((response) => {
+          Vue.delete(this.$state.loading, url);
+          return response;
+        });
+      },
     },
   });
 };

--- a/static-webapps/slate-portfolio-manager/src/store/emitter.js
+++ b/static-webapps/slate-portfolio-manager/src/store/emitter.js
@@ -1,0 +1,3 @@
+import mitt from 'mitt';
+
+export default mitt();

--- a/static-webapps/slate-portfolio-manager/src/store/useUi.js
+++ b/static-webapps/slate-portfolio-manager/src/store/useUi.js
@@ -4,6 +4,9 @@ export default defineStore('ui', {
   state: () => ({ alert: null, confirm: null }),
   actions: {
     alert(options) {
+      if (options && !options.actions) {
+        options.actions = [{ text: 'Close', click: () => this.alert(null) }];
+      }
       this.$state.alert = options;
     },
     confirm(body, action) {
@@ -20,7 +23,13 @@ export default defineStore('ui', {
             text: 'Confirm',
             click: () => {
               this.alert(null);
-              action();
+              Promise.resolve(action()).catch((error) => {
+                let message = `Uncaught exception: ${error.message}`;
+                if (error.response && error.response.data.message) {
+                  message = `The server returned an error: ${error.response.data.message}`;
+                }
+                this.alert({ body: message });
+              });
             },
           },
         ],

--- a/static-webapps/slate-portfolio-manager/src/store/useUi.js
+++ b/static-webapps/slate-portfolio-manager/src/store/useUi.js
@@ -29,6 +29,7 @@ export default defineStore('ui', {
                   message = `The server returned an error: ${error.response.data.message}`;
                 }
                 this.alert({ body: message });
+                throw error;
               });
             },
           },


### PR DESCRIPTION
This probably needs some copy tweaks. Right now the backend cache isn't being reset after you delete a portfolio. The first deletion seems to work fine (the server returns "success: true") but when the front end tries to refetch the data, the portfolio still exists. If you refresh the page, the portfolio is still there, but when you try to delete it you get a 404 error (so the first attempt must have been successful).

Below are some images showing what the delete button, "are you sure" prompt, and 404 error look like.

![image](https://user-images.githubusercontent.com/379151/198835713-583b27d6-2697-48de-9cd3-a2f3273f0794.png)

![image](https://user-images.githubusercontent.com/379151/198835736-25ed4a60-67ac-46fd-81a8-698354456082.png)
