### PR TITLE
 fix(advanced-portfolio-manager): remove loading after delete and update. Also refetch data [#725]

### DIFF
--- a/static-webapps/slate-portfolio-manager/src/components/sidebar/LevelPanel.vue
+++ b/static-webapps/slate-portfolio-manager/src/components/sidebar/LevelPanel.vue
@@ -189,7 +189,13 @@ export default {
     startDelete() {
       let body = `Are you sure you want to delete Year ${this.portfolio.Level}?`;
       body += ' This cannot be undone.';
-      const action = () => this.studentCompetencyStore.delete(this.portfolio.ID).then(this.refetch);
+      const action = () => this.studentCompetencyStore
+        .delete(this.portfolio.ID)
+        .then(this.refetch)
+        .catch((e) => {
+          this.refetch();
+          throw e;
+        });
       this.uiStore.confirm(body, action);
     },
   },

--- a/static-webapps/slate-portfolio-manager/src/store/defineRestStore.js
+++ b/static-webapps/slate-portfolio-manager/src/store/defineRestStore.js
@@ -95,6 +95,9 @@ export default ({
         return client.post(url, data).then((response) => {
           Vue.delete(this.$state.loading, url);
           return response;
+        }).catch((e) => {
+          Vue.delete(this.$state.loading, url);
+          throw e;
         });
       },
 
@@ -104,6 +107,9 @@ export default ({
         return client.post(url).then((response) => {
           Vue.delete(this.$state.loading, url);
           return response;
+        }).catch((e) => {
+          Vue.delete(this.$state.loading, url);
+          throw e;
         });
       },
     },


### PR DESCRIPTION
The api storage wasn't removing the loading state on fail.

[update-after-delete.webm](https://user-images.githubusercontent.com/379151/199506962-bcf31ac5-0eac-4ed0-b221-23d913871588.webm)
