### PR TITLE
feat(portfolio-manager): add unstyled drag-and-drop demo [#740]

### DIFF
--- a/static-webapps/slate-portfolio-manager/src/assets/app.scss
+++ b/static-webapps/slate-portfolio-manager/src/assets/app.scss
@@ -37,3 +37,15 @@ body {
     z-index: 99999;
   }
 }
+
+.level-panel.-drop-zone {
+  position: relative;
+  &:before {
+    background: green;
+    content: "";
+    display: block;
+    inset: 0;
+    position: absolute;
+    z-index: 1;
+  }
+}

--- a/static-webapps/slate-portfolio-manager/src/assets/app.scss
+++ b/static-webapps/slate-portfolio-manager/src/assets/app.scss
@@ -39,13 +39,7 @@ body {
 }
 
 .level-panel.-drop-zone {
-  position: relative;
-  &:before {
-    background: green;
-    content: "";
-    display: block;
-    inset: 0;
-    position: absolute;
-    z-index: 1;
+  .btn-danger, .skill-demos {
+    display: none;
   }
 }

--- a/static-webapps/slate-portfolio-manager/src/assets/app.scss
+++ b/static-webapps/slate-portfolio-manager/src/assets/app.scss
@@ -39,7 +39,11 @@ body {
 }
 
 .level-panel.-drop-zone {
-  .btn-danger, .skill-demos {
+  .level-panel__delete, .skill-demos {
     display: none;
+  }
+  &.-drag-source {
+    filter: grayscale(0.75);
+    opacity: 0.5;
   }
 }

--- a/static-webapps/slate-portfolio-manager/src/components/sidebar/LevelPanel.vue
+++ b/static-webapps/slate-portfolio-manager/src/components/sidebar/LevelPanel.vue
@@ -64,7 +64,7 @@
       />
       <div
         v-if="canDelete"
-        class="p-3 bg-cbl-level-10"
+        class="p-3 bg-cbl-level-10 level-panel__delete"
       >
         <button
           class="btn btn-danger"
@@ -121,9 +121,15 @@ export default {
     ...mapStores(useStudentCompetency, useUi),
 
     wrapperClass() {
+      const { Level } = this.portfolio;
+      const { dragging } = this.uiStore;
+      const isDroppable = dragging && dragging.type === 'move-skill-demo';
       return [
-        `level-panel mb-2 cbl-level-${this.portfolio.Level}`,
-        this.isDroppable && '-drop-zone',
+        `level-panel mb-2 cbl-level-${Level}`,
+        isDroppable && [
+          '-drop-zone',
+          dragging.Level === Level ? '-drag-source' : '-drag-target',
+        ],
       ];
     },
 
@@ -179,11 +185,6 @@ export default {
     canDelete() {
       const nextLevel = this.visibleLevels.find((level) => level > this.portfolio.Level);
       return this.preppedSkillDemos.length === 0 && !nextLevel;
-    },
-
-    isDroppable() {
-      const { dragging } = this.uiStore;
-      return dragging && dragging.type === 'move-skill-demo';
     },
   },
 

--- a/static-webapps/slate-portfolio-manager/src/components/sidebar/LevelPanel.vue
+++ b/static-webapps/slate-portfolio-manager/src/components/sidebar/LevelPanel.vue
@@ -1,5 +1,10 @@
 <template>
-  <div :class="`level-panel mb-2 cbl-level-${portfolio.Level}`">
+  <div
+    :class="wrapperClass"
+    @drop="drop"
+    @dragover.prevent
+    @dragenter.prevent
+  >
     <b-container
       v-b-toggle="collapseId"
       class="bg-cbl-level-50"
@@ -115,6 +120,13 @@ export default {
   computed: {
     ...mapStores(useStudentCompetency, useUi),
 
+    wrapperClass() {
+      return [
+        `level-panel mb-2 cbl-level-${this.portfolio.Level}`,
+        this.isDroppable && '-drop-zone',
+      ];
+    },
+
     stats() {
       const { BaselineRating, demonstrationsAverage, growth } = this.portfolio;
       const format = (value) => {
@@ -168,6 +180,11 @@ export default {
       const nextLevel = this.visibleLevels.find((level) => level > this.portfolio.Level);
       return this.preppedSkillDemos.length === 0 && !nextLevel;
     },
+
+    isDroppable() {
+      const { dragging } = this.uiStore;
+      return dragging && dragging.type === 'skill-demo';
+    },
   },
 
   methods: {
@@ -191,6 +208,12 @@ export default {
           throw e;
         });
       this.uiStore.confirm(body, action);
+    },
+    drop() {
+      const { type, action } = this.uiStore.$state.dragging || {};
+      if (type === 'move-skill-demo') {
+        action(this.portfolio.Level);
+      }
     },
   },
 };

--- a/static-webapps/slate-portfolio-manager/src/components/sidebar/LevelPanel.vue
+++ b/static-webapps/slate-portfolio-manager/src/components/sidebar/LevelPanel.vue
@@ -183,7 +183,7 @@ export default {
 
     isDroppable() {
       const { dragging } = this.uiStore;
-      return dragging && dragging.type === 'skill-demo';
+      return dragging && dragging.type === 'move-skill-demo';
     },
   },
 

--- a/static-webapps/slate-portfolio-manager/src/components/sidebar/SkillDemoCard.vue
+++ b/static-webapps/slate-portfolio-manager/src/components/sidebar/SkillDemoCard.vue
@@ -1,5 +1,9 @@
 <template>
-  <div :class="wrapperClass">
+  <div
+    :class="wrapperClass"
+    draggable="true"
+    @drag="drag"
+  >
     <div class="skill-demo__rating py-1 bg-cbl-level">
       <font-awesome-icon
         v-if="demo.Override"
@@ -102,6 +106,16 @@ export default {
       };
       this.uiStore.confirm(body, action);
     },
+    drag() {
+      const { ID } = this.demo;
+      const { level } = this;
+      this.uiStore.startDragging({
+        ID,
+        Level: level,
+        type: 'move-skill-demo',
+        action: this.setTargetLevel,
+      });
+    },
   },
 };
 </script>
@@ -143,6 +157,7 @@ export default {
 
     &__grabber {
       background-color: #eee;
+      cursor: pointer;
       flex: 1 1 0;
     }
 

--- a/static-webapps/slate-portfolio-manager/src/components/sidebar/SkillDemoCard.vue
+++ b/static-webapps/slate-portfolio-manager/src/components/sidebar/SkillDemoCard.vue
@@ -96,6 +96,10 @@ export default {
 
   methods: {
     setTargetLevel(TargetLevel) {
+      if (TargetLevel === this.level) {
+        // skill demo-card was dropped on current portfolio level
+        return;
+      }
       const { ID } = this.demo;
       const data = [{ ID, TargetLevel }];
       const body = `Are you sure you want to move this to level ${TargetLevel}?`;

--- a/static-webapps/slate-portfolio-manager/src/store/useUi.js
+++ b/static-webapps/slate-portfolio-manager/src/store/useUi.js
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia';
 
 export default defineStore('ui', {
-  state: () => ({ alert: null, confirm: null }),
+  state: () => ({ alert: null, confirm: null, dragging: null }),
   actions: {
     alert(options) {
       if (options && !options.actions) {
@@ -35,6 +35,14 @@ export default defineStore('ui', {
           },
         ],
       });
+    },
+    startDragging(options) {
+      this.$state.dragging = options;
+      document.addEventListener(
+        'dragend',
+        () => { this.$state.dragging = null; },
+        { once: true },
+      );
     },
   },
 });


### PR DESCRIPTION
Fixes #740. Skill demos can now moved between levels using the mouse.

* Dragging a skill demo collapses all the children of the skill demo (bottom lighter section is empty)
* Dropping it moves between levels
* Dropping on original level has no effect
* State management functionality added to src/store.useUi.js

Demonstration:

[drag-skill-demo.webm](https://user-images.githubusercontent.com/379151/204358189-a6a40f28-cf30-4177-b5bd-02405abddf2d.webm)
