### PR TITLE
fix: correct text clearing issue in task selector

### DIFF
--- a/sencha-workspace/packages/slate-cbl/src/field/TaskSelector.js
+++ b/sencha-workspace/packages/slate-cbl/src/field/TaskSelector.js
@@ -18,7 +18,6 @@ Ext.define('Slate.cbl.field.TaskSelector', {
         selectOnTab: false
     },
 
-
     store: {
         model: 'Slate.cbl.model.tasks.Task',
         proxy: {
@@ -27,6 +26,7 @@ Ext.define('Slate.cbl.field.TaskSelector', {
             include: ['Creator']
         },
         remoteSort: true,
+        pageSize: 0,
         sorters: [{
             property: 'Created',
             direction: 'DESC'

--- a/sencha-workspace/packages/slate-cbl/src/field/TaskSelector.js
+++ b/sencha-workspace/packages/slate-cbl/src/field/TaskSelector.js
@@ -2,7 +2,7 @@ Ext.define('Slate.cbl.field.TaskSelector', {
     extend: 'Slate.cbl.field.ClearableSelector',
     xtype: 'slate-cbl-taskselector',
     requires: [
-        'Slate.cbl.store.tasks.Tasks'
+        'Slate.cbl.model.tasks.Task'
     ],
 
 
@@ -20,7 +20,7 @@ Ext.define('Slate.cbl.field.TaskSelector', {
 
 
     store: {
-        type: 'slate-cbl-tasks',
+        model: 'Slate.cbl.model.tasks.Task',
         proxy: {
             type: 'slate-cbl-tasks',
             summary: true,

--- a/sencha-workspace/packages/slate-cbl/src/field/TaskSelector.js
+++ b/sencha-workspace/packages/slate-cbl/src/field/TaskSelector.js
@@ -26,7 +26,7 @@ Ext.define('Slate.cbl.field.TaskSelector', {
             include: ['Creator']
         },
         remoteSort: true,
-        pageSize: 0,
+        pageSize: 30,
         sorters: [{
             property: 'Created',
             direction: 'DESC'


### PR DESCRIPTION
the task selector used in the clone task and subtask fields of the task form allow the user to type a string to filter results.  Currently, when the user types a text string and results are returned, the query text dissappears.  This creates confusion and does not allow the user to continue typing to make their query string more precise.

This issues exists because the Task store does some post processing to decorate results with subtask arrays and parent task references.  These references are not necessary when populating the task selector, so I altered the task selector to use the Task model rather than the task store, bypassing this post-processing.

For specificity, the problem is caused by one specific line in the task store: `task.set('SubTasks', subTasks, { dirty: false });` the issue could also have been addressed by adding the silent flag to this setter like this:
`task.set('SubTasks', subTasks, { dirty: false, silent: true });` But the ExtJS docs caution against the use of this flag, it could theoretically affect other parts of the app, and it seemed unnecessary in order to address this specific issue.