### PR TITLE
fix(ratings): overrides should get bumped by real ratings added after them

### DIFF
--- a/cypress/fixtures/cbl/calculations.json
+++ b/cypress/fixtures/cbl/calculations.json
@@ -319,6 +319,15 @@
                 "growth": "1.2",
                 "progress": "63"
             }
+        },
+        "HW": {
+            "HW.2": {
+                "description": "Ratings added after overrides with and without flushing out the override",
+                "baseline": null,
+                "average": "8.8",
+                "growth": "0.8",
+                "progress": "90"
+            }
         }
     }
 }

--- a/cypress/integration/cbl/api/student-competencies.js
+++ b/cypress/integration/cbl/api/student-competencies.js
@@ -15,10 +15,10 @@ describe('CBL / API / StudentCompetency', () => {
             expect(response).property('status').to.eq(200);
             expect(response).property('body').to.be.an('object');
             expect(response.body).property('success').to.be.true;
-            expect(response.body).property('total').to.eq(655);
+            expect(response.body).property('total').to.eq(656);
             expect(response.body).property('limit').to.eq(0);
             expect(response.body).property('data').to.be.an('array');
-            expect(response.body.data).to.have.length(655);
+            expect(response.body.data).to.have.length(656);
             expect(response.body.data[0]).to.include({
                 ID: 584,
                 Class: 'Slate\\CBL\\StudentCompetency',

--- a/cypress/integration/cbl/progress/student-dashboard.js
+++ b/cypress/integration/cbl/progress/student-dashboard.js
@@ -247,4 +247,73 @@ describe('CBL / Progress / Student Dashboard', () => {
             });
         });
     });
+
+    it('Verify student5 test cases render correctly', () => {
+
+        // load student2-HW dashboard
+        cy.loginAs('student5');
+        cy.visit('/cbl/dashboards/demonstrations/student#me/HW');
+
+        // ensure student competencies loaded
+        cy.wait('@getStudentCompetencies');
+        cy.get('@getStudentCompetencies.all').should('have.length', 1);
+
+        // ensure recent progress loaded
+        cy.wait('@getRecentProgress');
+        cy.get('@getRecentProgress.all').should('have.length', 1);
+
+        // verify content updated
+        cy.get('.slate-demonstrations-student-competenciessummary span')
+            .should('have.text', 'Health and Wellness');
+
+        cy.get('.slate-demonstrations-student-cardsct .slate-demonstrations-student-competencycard')
+            .should('have.length', 1);
+
+        // verify recent progress feed
+        cy.get('.slate-tasks-student-recentactivity tbody tr .level-col > div').should('have.length', 9).should(($ratingCells) => {
+            expect($ratingCells[0]).to.have.class('cbl-level-9').and.have.text('10');
+            expect($ratingCells[1]).to.have.class('cbl-level-9').and.have.text('10');
+            expect($ratingCells[2]).to.have.class('cbl-level-9').and.have.descendants('.fa-check');
+            expect($ratingCells[3]).to.have.class('cbl-level-9').and.have.descendants('.fa-check');
+            expect($ratingCells[4]).to.have.class('cbl-level-9').and.have.descendants('.fa-check');
+            expect($ratingCells[5]).to.have.class('cbl-level-9').and.have.descendants('.fa-check');
+            expect($ratingCells[6]).to.have.class('cbl-level-9').and.have.text('8');
+            expect($ratingCells[7]).to.have.class('cbl-level-9').and.have.text('8');
+            expect($ratingCells[8]).to.have.class('cbl-level-9').and.have.text('8');
+        });
+
+        // verify skill renderings for HW.2
+        cy.get('.slate-demonstrations-student-competencycard[data-competency="13"]').should('have.class', 'cbl-level-9');
+        cy.get('.cbl-skill[data-skill="HW.2.1"]').within(() => {
+            cy.get('.cbl-skill-complete-indicator').should('not.have.class', 'is-checked');
+            cy.get('.cbl-skill-demo').should('have.length', 2).should(($skillCells) => {
+                expect($skillCells[0]).to.have.text('8');
+                expect($skillCells[1]).to.have.class('cbl-skill-demo-empty');
+            });
+        });
+        cy.get('.cbl-skill[data-skill="HW.2.2"').within(() => {
+            cy.get('.cbl-skill-complete-indicator').should('have.class', 'is-checked');
+            cy.get('.cbl-skill-demo').should('have.length', 2).should(($skillCells) => {
+                expect($skillCells[0]).to.have.text('8');
+                expect($skillCells[1]).to.have.class('cbl-skill-override')
+                    .and.have.attr('title', '[Overridden]')
+                    .and.have.descendants('.fa-check');
+            });
+        });
+        cy.get('.cbl-skill[data-skill="HW.2.3"').within(() => {
+            cy.get('.cbl-skill-complete-indicator').should('have.class', 'is-checked');
+            cy.get('.cbl-skill-demo').should('have.length', 2).should(($skillCells) => {
+                expect($skillCells[0]).to.have.text('8');
+                expect($skillCells[1]).to.have.text('10');
+            });
+        });
+        cy.get('.cbl-skill[data-skill="HW.2.4"').within(() => {
+            cy.get('.cbl-skill-complete-indicator').should('have.class', 'is-checked');
+            cy.get('.cbl-skill-demo').should('have.length', 1).should(($skillCells) => {
+                expect($skillCells[0]).to.have.class('cbl-skill-override')
+                    .and.have.attr('title', '[Overridden]')
+                    .and.have.descendants('.fa-check');
+            });
+        });
+    });
 });

--- a/cypress/integration/cbl/progress/student-dashboard.js
+++ b/cypress/integration/cbl/progress/student-dashboard.js
@@ -315,5 +315,14 @@ describe('CBL / Progress / Student Dashboard', () => {
                     .and.have.descendants('.fa-check');
             });
         });
+        cy.get('.cbl-skill[data-skill="HW.2.5"').within(() => {
+            cy.get('.cbl-skill-complete-indicator').should('have.class', 'is-checked');
+            cy.get('.cbl-skill-demo').should('have.length', 2).should(($skillCells) => {
+                expect($skillCells[0]).to.have.text('10');
+                expect($skillCells[1]).to.have.class('cbl-skill-override')
+                    .and.have.attr('title', '[Overridden]')
+                    .and.have.descendants('.fa-check');
+            });
+        });
     });
 });

--- a/cypress/integration/cbl/progress/teacher-dashboard.js
+++ b/cypress/integration/cbl/progress/teacher-dashboard.js
@@ -664,8 +664,9 @@ describe('CBL / Progress / Teacher Dashboard', () => {
                 // HW.2.5 - student5
                 expect($skillCells[3]).to.have.class('cbl-level-9');
                 $demoItems = $skillCells.eq(3).find('.cbl-skill-demo');
-                expect($demoItems).to.have.length(1);
-                expect($demoItems[0]).to.have.class('cbl-skill-demo-counted').and.have.class('cbl-skill-demo-override').and.have.descendants('.fa-check');
+                expect($demoItems).to.have.length(2);
+                expect($demoItems[0]).to.have.class('cbl-skill-demo-counted').and.have.text('10');
+                expect($demoItems[1]).to.have.class('cbl-skill-demo-counted').and.have.class('cbl-skill-demo-override').and.have.descendants('.fa-check');
             }
         });
     });

--- a/cypress/integration/cbl/progress/teacher-dashboard.js
+++ b/cypress/integration/cbl/progress/teacher-dashboard.js
@@ -286,7 +286,7 @@ describe('CBL / Progress / Teacher Dashboard', () => {
 
         cy.extGet('slate-demonstrations-teacher-dashboard')
             .find('.cbl-grid-student-name')
-            .should('have.length', 3)
+            .should('have.length', 4)
             .first()
                 .should('have.text', 'Student Slate');
 
@@ -356,7 +356,7 @@ describe('CBL / Progress / Teacher Dashboard', () => {
 
         cy.extGet('slate-demonstrations-teacher-dashboard')
             .find('.cbl-grid-student-name')
-            .should('have.length', 3)
+            .should('have.length', 4)
             .first()
                 .should('have.text', 'Student Slate');
 
@@ -385,7 +385,7 @@ describe('CBL / Progress / Teacher Dashboard', () => {
                 // HW.1.1
                 expect($skillRows[0]).to.have.attr('data-skill', '48');
                 $skillCells = $skillRows.eq(0).find('.cbl-grid-demos-cell');
-                expect($skillCells).to.have.length(3);
+                expect($skillCells).to.have.length(4);
 
                 // HW.1.1 - student
                 expect($skillCells[0]).to.have.class('cbl-level-10');
@@ -407,10 +407,16 @@ describe('CBL / Progress / Teacher Dashboard', () => {
                 expect($demoItems[1]).to.have.class('cbl-skill-demo-uncounted').and.have.html('&nbsp;');
                 expect($demoItems[2]).to.have.class('cbl-skill-demo-uncounted').and.have.html('&nbsp;');
 
+                // HW.1.1 - student5
+                expect([...$skillCells[3].classList].filter(className => className.startsWith('cbl-level-'))).to.have.length(0);
+                $demoItems = $skillCells.eq(3).find('.cbl-skill-demo');
+                expect($demoItems).to.have.length(1);
+                expect($demoItems[0]).to.have.class('cbl-skill-demo-uncounted').and.have.html('&nbsp;');
+
                 // HW.1.2
                 expect($skillRows[1]).to.have.attr('data-skill', '49');
                 $skillCells = $skillRows.eq(1).find('.cbl-grid-demos-cell');
-                expect($skillCells).to.have.length(3);
+                expect($skillCells).to.have.length(4);
 
                 // HW.1.2 - student
                 expect($skillCells[0]).to.have.class('cbl-level-10');
@@ -431,11 +437,17 @@ describe('CBL / Progress / Teacher Dashboard', () => {
                 expect($demoItems[0]).to.have.class('cbl-skill-demo-counted').and.have.text('8');
                 expect($demoItems[1]).to.have.class('cbl-skill-demo-uncounted').and.have.html('&nbsp;');
                 expect($demoItems[2]).to.have.class('cbl-skill-demo-uncounted').and.have.html('&nbsp;');
+
+                // HW.1.2 - student5
+                expect([...$skillCells[3].classList].filter(className => className.startsWith('cbl-level-'))).to.have.length(0);
+                $demoItems = $skillCells.eq(3).find('.cbl-skill-demo');
+                expect($demoItems).to.have.length(1);
+                expect($demoItems[0]).to.have.class('cbl-skill-demo-uncounted').and.have.html('&nbsp;');
 
                 // HW.1.3
                 expect($skillRows[2]).to.have.attr('data-skill', '50');
                 $skillCells = $skillRows.eq(2).find('.cbl-grid-demos-cell');
-                expect($skillCells).to.have.length(3);
+                expect($skillCells).to.have.length(4);
 
                 // HW.1.2 - student
                 expect($skillCells[0]).to.have.class('cbl-level-10');
@@ -457,27 +469,39 @@ describe('CBL / Progress / Teacher Dashboard', () => {
                 expect($demoItems[1]).to.have.class('cbl-skill-demo-uncounted').and.have.html('&nbsp;');
                 expect($demoItems[2]).to.have.class('cbl-skill-demo-uncounted').and.have.html('&nbsp;');
 
+                // HW.1.3 - student5
+                expect([...$skillCells[3].classList].filter(className => className.startsWith('cbl-level-'))).to.have.length(0);
+                $demoItems = $skillCells.eq(3).find('.cbl-skill-demo');
+                expect($demoItems).to.have.length(1);
+                expect($demoItems[0]).to.have.class('cbl-skill-demo-uncounted').and.have.html('&nbsp;');
+
                 // HW.1.4
                 expect($skillRows[3]).to.have.attr('data-skill', '51');
                 $skillCells = $skillRows.eq(3).find('.cbl-grid-demos-cell');
-                expect($skillCells).to.have.length(3);
+                expect($skillCells).to.have.length(4);
 
-                // HW.1.2 - student
+                // HW.1.4 - student
                 expect($skillCells[0]).to.have.class('cbl-level-10');
                 $demoItems = $skillCells.eq(0).find('.cbl-skill-demo');
                 expect($demoItems).to.have.length(0);
 
-                // HW.1.2 - student 2
+                // HW.1.4 - student 2
                 expect($skillCells[1]).to.have.class('cbl-level-9');
                 $demoItems = $skillCells.eq(1).find('.cbl-skill-demo');
                 expect($demoItems).to.have.length(2);
                 expect($demoItems[0]).to.have.class('cbl-skill-demo-counted').and.have.text('7');
                 expect($demoItems[1]).to.have.class('cbl-skill-demo-uncounted').and.have.html('&nbsp;');
 
-                // HW.1.2 - student 3
+                // HW.1.4 - student 3
                 expect($skillCells[2]).to.have.class('cbl-level-11');
                 $demoItems = $skillCells.eq(2).find('.cbl-skill-demo');
                 expect($demoItems).to.have.length(0);
+
+                // HW.1.4 - student5
+                expect([...$skillCells[3].classList].filter(className => className.startsWith('cbl-level-'))).to.have.length(0);
+                $demoItems = $skillCells.eq(3).find('.cbl-skill-demo');
+                expect($demoItems).to.have.length(1);
+                expect($demoItems[0]).to.have.class('cbl-skill-demo-uncounted').and.have.html('&nbsp;');
             }
         });
     });
@@ -493,7 +517,7 @@ describe('CBL / Progress / Teacher Dashboard', () => {
                 // HW.2.1
                 expect($skillRows[0]).to.have.attr('data-skill', '52');
                 $skillCells = $skillRows.eq(0).find('.cbl-grid-demos-cell');
-                expect($skillCells).to.have.length(3);
+                expect($skillCells).to.have.length(4);
 
                 // HW.2.1 - student
                 expect($skillCells[0]).to.have.class('cbl-level-10');
@@ -514,10 +538,17 @@ describe('CBL / Progress / Teacher Dashboard', () => {
                 expect($demoItems[1]).to.have.class('cbl-skill-demo-counted').and.have.text('9');
                 expect($demoItems[2]).to.have.class('cbl-skill-demo-uncounted').and.have.html('&nbsp;');
 
+                // HW.2.1 - student5
+                expect($skillCells[3]).to.have.class('cbl-level-9');
+                $demoItems = $skillCells.eq(3).find('.cbl-skill-demo');
+                expect($demoItems).to.have.length(2);
+                expect($demoItems[0]).to.have.class('cbl-skill-demo-counted').and.have.text('8');
+                expect($demoItems[1]).to.have.class('cbl-skill-demo-uncounted').and.have.html('&nbsp;');
+
                 // HW.2.2
                 expect($skillRows[1]).to.have.attr('data-skill', '53');
                 $skillCells = $skillRows.eq(1).find('.cbl-grid-demos-cell');
-                expect($skillCells).to.have.length(3);
+                expect($skillCells).to.have.length(4);
 
                 // HW.2.2 - student
                 expect($skillCells[0]).to.have.class('cbl-level-10');
@@ -538,10 +569,17 @@ describe('CBL / Progress / Teacher Dashboard', () => {
                 expect($demoItems[1]).to.have.class('cbl-skill-demo-counted').and.have.text('9');
                 expect($demoItems[2]).to.have.class('cbl-skill-demo-uncounted').and.have.html('&nbsp;');
 
+                // HW.2.2 - student5
+                expect($skillCells[3]).to.have.class('cbl-level-9');
+                $demoItems = $skillCells.eq(3).find('.cbl-skill-demo');
+                expect($demoItems).to.have.length(2);
+                expect($demoItems[0]).to.have.class('cbl-skill-demo-counted').and.have.text('8');
+                expect($demoItems[1]).to.have.class('cbl-skill-demo-counted').and.have.class('cbl-skill-demo-override').and.have.descendants('.fa-check');
+
                 // HW.2.3
                 expect($skillRows[2]).to.have.attr('data-skill', '54');
                 $skillCells = $skillRows.eq(2).find('.cbl-grid-demos-cell');
-                expect($skillCells).to.have.length(3);
+                expect($skillCells).to.have.length(4);
 
                 // HW.2.3 - student
                 expect($skillCells[0]).to.have.class('cbl-level-10');
@@ -563,10 +601,17 @@ describe('CBL / Progress / Teacher Dashboard', () => {
                 expect($demoItems[1]).to.have.class('cbl-skill-demo-uncounted').and.have.html('&nbsp;');
                 expect($demoItems[2]).to.have.class('cbl-skill-demo-uncounted').and.have.html('&nbsp;');
 
+                // HW.2.3 - student5
+                expect($skillCells[3]).to.have.class('cbl-level-9');
+                $demoItems = $skillCells.eq(3).find('.cbl-skill-demo');
+                expect($demoItems).to.have.length(2);
+                expect($demoItems[0]).to.have.class('cbl-skill-demo-counted').and.have.text('8');
+                expect($demoItems[1]).to.have.class('cbl-skill-demo-counted').and.have.text('10');
+
                 // HW.2.4
                 expect($skillRows[3]).to.have.attr('data-skill', '55');
                 $skillCells = $skillRows.eq(3).find('.cbl-grid-demos-cell');
-                expect($skillCells).to.have.length(3);
+                expect($skillCells).to.have.length(4);
 
                 // HW.2.4 - student
                 expect($skillCells[0]).to.have.class('cbl-level-10');
@@ -588,10 +633,16 @@ describe('CBL / Progress / Teacher Dashboard', () => {
                 expect($demoItems[1]).to.have.class('cbl-skill-demo-uncounted').and.have.html('&nbsp;');
                 expect($demoItems[2]).to.have.class('cbl-skill-demo-uncounted').and.have.html('&nbsp;');
 
+                // HW.2.4 - student5
+                expect($skillCells[3]).to.have.class('cbl-level-9');
+                $demoItems = $skillCells.eq(3).find('.cbl-skill-demo');
+                expect($demoItems).to.have.length(1);
+                expect($demoItems[0]).to.have.class('cbl-skill-demo-counted').and.have.class('cbl-skill-demo-override').and.have.descendants('.fa-check');
+
                 // HW.2.5
                 expect($skillRows[4]).to.have.attr('data-skill', '56');
                 $skillCells = $skillRows.eq(4).find('.cbl-grid-demos-cell');
-                expect($skillCells).to.have.length(3);
+                expect($skillCells).to.have.length(4);
 
                 // HW.2.5 - student
                 expect($skillCells[0]).to.have.class('cbl-level-10');
@@ -609,6 +660,12 @@ describe('CBL / Progress / Teacher Dashboard', () => {
                 expect($skillCells[2]).to.have.class('cbl-level-11');
                 $demoItems = $skillCells.eq(2).find('.cbl-skill-demo');
                 expect($demoItems).to.have.length(0);
+
+                // HW.2.5 - student5
+                expect($skillCells[3]).to.have.class('cbl-level-9');
+                $demoItems = $skillCells.eq(3).find('.cbl-skill-demo');
+                expect($demoItems).to.have.length(1);
+                expect($demoItems[0]).to.have.class('cbl-skill-demo-counted').and.have.class('cbl-skill-demo-override').and.have.descendants('.fa-check');
             }
         });
     });
@@ -624,7 +681,7 @@ describe('CBL / Progress / Teacher Dashboard', () => {
                 // HW.3.1
                 expect($skillRows[0]).to.have.attr('data-skill', '57');
                 $skillCells = $skillRows.eq(0).find('.cbl-grid-demos-cell');
-                expect($skillCells).to.have.length(3);
+                expect($skillCells).to.have.length(4);
 
                 // HW.3.1 - student
                 expect($skillCells[0]).to.have.class('cbl-level-9');
@@ -646,10 +703,16 @@ describe('CBL / Progress / Teacher Dashboard', () => {
                 expect($demoItems[1]).to.have.class('cbl-skill-demo-counted').and.have.text('9');
                 expect($demoItems[2]).to.have.class('cbl-skill-demo-counted').and.have.text('11');
 
+                // HW.3.1 - student5
+                expect([...$skillCells[3].classList].filter(className => className.startsWith('cbl-level-'))).to.have.length(0);
+                $demoItems = $skillCells.eq(3).find('.cbl-skill-demo');
+                expect($demoItems).to.have.length(1);
+                expect($demoItems[0]).to.have.class('cbl-skill-demo-uncounted').and.have.html('&nbsp;');
+
                 // HW.3.2
                 expect($skillRows[1]).to.have.attr('data-skill', '58');
                 $skillCells = $skillRows.eq(1).find('.cbl-grid-demos-cell');
-                expect($skillCells).to.have.length(3);
+                expect($skillCells).to.have.length(4);
 
                 // HW.3.2 - student
                 expect($skillCells[0]).to.have.class('cbl-level-9');
@@ -671,10 +734,16 @@ describe('CBL / Progress / Teacher Dashboard', () => {
                 expect($demoItems[1]).to.have.class('cbl-skill-demo-counted').and.have.text('10');
                 expect($demoItems[2]).to.have.class('cbl-skill-demo-uncounted').and.have.html('&nbsp;');
 
+                // HW.3.2 - student5
+                expect([...$skillCells[3].classList].filter(className => className.startsWith('cbl-level-'))).to.have.length(0);
+                $demoItems = $skillCells.eq(3).find('.cbl-skill-demo');
+                expect($demoItems).to.have.length(1);
+                expect($demoItems[0]).to.have.class('cbl-skill-demo-uncounted').and.have.html('&nbsp;');
+
                 // HW.3.3
                 expect($skillRows[2]).to.have.attr('data-skill', '59');
                 $skillCells = $skillRows.eq(2).find('.cbl-grid-demos-cell');
-                expect($skillCells).to.have.length(3);
+                expect($skillCells).to.have.length(4);
 
                 // HW.3.3 - student
                 expect($skillCells[0]).to.have.class('cbl-level-9');
@@ -697,10 +766,16 @@ describe('CBL / Progress / Teacher Dashboard', () => {
                 expect($demoItems[1]).to.have.class('cbl-skill-demo-uncounted').and.have.html('&nbsp;');
                 expect($demoItems[2]).to.have.class('cbl-skill-demo-uncounted').and.have.html('&nbsp;');
 
+                // HW.3.3 - student5
+                expect([...$skillCells[3].classList].filter(className => className.startsWith('cbl-level-'))).to.have.length(0);
+                $demoItems = $skillCells.eq(3).find('.cbl-skill-demo');
+                expect($demoItems).to.have.length(1);
+                expect($demoItems[0]).to.have.class('cbl-skill-demo-uncounted').and.have.html('&nbsp;');
+
                 // HW.3.4
                 expect($skillRows[3]).to.have.attr('data-skill', '60');
                 $skillCells = $skillRows.eq(3).find('.cbl-grid-demos-cell');
-                expect($skillCells).to.have.length(3);
+                expect($skillCells).to.have.length(4);
 
                 // HW.3.4 - student
                 expect($skillCells[0]).to.have.class('cbl-level-9');
@@ -720,6 +795,12 @@ describe('CBL / Progress / Teacher Dashboard', () => {
                 expect($skillCells[2]).to.have.class('cbl-level-11');
                 $demoItems = $skillCells.eq(2).find('.cbl-skill-demo');
                 expect($demoItems).to.have.length(0);
+
+                // HW.3.4 - student5
+                expect([...$skillCells[3].classList].filter(className => className.startsWith('cbl-level-'))).to.have.length(0);
+                $demoItems = $skillCells.eq(3).find('.cbl-skill-demo');
+                expect($demoItems).to.have.length(1);
+                expect($demoItems[0]).to.have.class('cbl-skill-demo-uncounted').and.have.html('&nbsp;');
             }
         });
     });

--- a/fixtures/cbl_demonstration_skills.sql
+++ b/fixtures/cbl_demonstration_skills.sql
@@ -2510,6 +2510,15 @@ INSERT INTO `cbl_demonstration_skills` VALUES (2540,'Slate\\CBL\\Demonstrations\
 INSERT INTO `cbl_demonstration_skills` VALUES (2541,'Slate\\CBL\\Demonstrations\\DemonstrationSkill','2022-08-21 16:32:56',1,NULL,NULL,260,128,11,0,0);
 INSERT INTO `cbl_demonstration_skills` VALUES (2542,'Slate\\CBL\\Demonstrations\\DemonstrationSkill','2022-08-21 16:32:56',1,NULL,NULL,260,129,11,0,0);
 INSERT INTO `cbl_demonstration_skills` VALUES (2543,'Slate\\CBL\\Demonstrations\\DemonstrationSkill','2022-08-21 16:33:38',1,NULL,NULL,261,126,11,0,0);
+INSERT INTO `cbl_demonstration_skills` VALUES (2544,'Slate\\CBL\\Demonstrations\\DemonstrationSkill','2022-12-29 20:57:47',2,NULL,NULL,262,52,9,8,0);
+INSERT INTO `cbl_demonstration_skills` VALUES (2545,'Slate\\CBL\\Demonstrations\\DemonstrationSkill','2022-12-29 20:57:47',2,NULL,NULL,262,53,9,8,0);
+INSERT INTO `cbl_demonstration_skills` VALUES (2546,'Slate\\CBL\\Demonstrations\\DemonstrationSkill','2022-12-29 20:57:47',2,NULL,NULL,262,54,9,8,0);
+INSERT INTO `cbl_demonstration_skills` VALUES (2547,'Slate\\CBL\\Demonstrations\\DemonstrationSkill','2022-12-29 20:57:54',2,NULL,NULL,263,53,9,NULL,1);
+INSERT INTO `cbl_demonstration_skills` VALUES (2548,'Slate\\CBL\\Demonstrations\\DemonstrationSkill','2022-12-29 20:58:00',2,NULL,NULL,264,54,9,NULL,1);
+INSERT INTO `cbl_demonstration_skills` VALUES (2549,'Slate\\CBL\\Demonstrations\\DemonstrationSkill','2022-12-29 20:58:05',2,NULL,NULL,265,55,9,NULL,1);
+INSERT INTO `cbl_demonstration_skills` VALUES (2550,'Slate\\CBL\\Demonstrations\\DemonstrationSkill','2022-12-29 20:58:10',2,NULL,NULL,266,56,9,NULL,1);
+INSERT INTO `cbl_demonstration_skills` VALUES (2551,'Slate\\CBL\\Demonstrations\\DemonstrationSkill','2022-12-29 20:59:06',2,NULL,NULL,267,56,9,10,0);
+INSERT INTO `cbl_demonstration_skills` VALUES (2552,'Slate\\CBL\\Demonstrations\\DemonstrationSkill','2022-12-29 20:59:06',2,NULL,NULL,267,54,9,10,0);
 
 
 CREATE TABLE `history_cbl_demonstration_skills` (

--- a/fixtures/cbl_demonstrations.sql
+++ b/fixtures/cbl_demonstrations.sql
@@ -275,6 +275,12 @@ INSERT INTO `cbl_demonstrations` VALUES (258,'Slate\\CBL\\Demonstrations\\Experi
 INSERT INTO `cbl_demonstrations` VALUES (259,'Slate\\CBL\\Demonstrations\\ExperienceDemonstration','2022-08-16 22:29:17',2,NULL,NULL,27,'2022-08-16 22:28:41',NULL,NULL,'Presentation of Learning','All M\'s','Multimedia Presentation');
 INSERT INTO `cbl_demonstrations` VALUES (260,'Slate\\CBL\\Demonstrations\\ExperienceDemonstration','2022-08-21 16:32:56',1,NULL,NULL,27,'2022-08-21 16:28:27',NULL,NULL,'Studio','Missing studio 1','Data Analysis Task');
 INSERT INTO `cbl_demonstrations` VALUES (261,'Slate\\CBL\\Demonstrations\\ExperienceDemonstration','2022-08-21 16:33:38',1,NULL,NULL,27,'2022-08-21 16:32:57',NULL,NULL,'Studio','Missing Studio 2','Engineering Design');
+INSERT INTO `cbl_demonstrations` VALUES (262,'Slate\\CBL\\Demonstrations\\ExperienceDemonstration','2022-12-29 20:57:47',2,NULL,NULL,28,'2022-12-29 20:57:37',NULL,NULL,'Studio','Initial demonstration before overrides','Data Analysis Task');
+INSERT INTO `cbl_demonstrations` VALUES (263,'Slate\\CBL\\Demonstrations\\OverrideDemonstration','2022-12-29 20:57:54',2,NULL,NULL,28,'2022-12-29 20:57:54',NULL,NULL,NULL,NULL,NULL);
+INSERT INTO `cbl_demonstrations` VALUES (264,'Slate\\CBL\\Demonstrations\\OverrideDemonstration','2022-12-29 20:58:00',2,NULL,NULL,28,'2022-12-29 20:57:58',NULL,NULL,NULL,NULL,NULL);
+INSERT INTO `cbl_demonstrations` VALUES (265,'Slate\\CBL\\Demonstrations\\OverrideDemonstration','2022-12-29 20:58:05',2,NULL,NULL,28,'2022-12-29 20:58:04',NULL,NULL,NULL,NULL,NULL);
+INSERT INTO `cbl_demonstrations` VALUES (266,'Slate\\CBL\\Demonstrations\\OverrideDemonstration','2022-12-29 20:58:10',2,NULL,NULL,28,'2022-12-29 20:58:08',NULL,NULL,NULL,NULL,NULL);
+INSERT INTO `cbl_demonstrations` VALUES (267,'Slate\\CBL\\Demonstrations\\ExperienceDemonstration','2022-12-29 20:59:06',2,NULL,NULL,28,'2022-12-29 20:58:50',NULL,NULL,'Studio','Initial demonstration after overrides','Data Analysis Task');
 
 
 CREATE TABLE `history_cbl_demonstrations` (

--- a/fixtures/cbl_student_competencies.sql
+++ b/fixtures/cbl_student_competencies.sql
@@ -670,3 +670,4 @@ INSERT INTO `cbl_student_competencies` VALUES (652,'Slate\\CBL\\StudentCompetenc
 INSERT INTO `cbl_student_competencies` VALUES (653,'Slate\\CBL\\StudentCompetency','2022-07-02 11:52:37',2,6,12,9,'enrollment',NULL);
 INSERT INTO `cbl_student_competencies` VALUES (654,'Slate\\CBL\\StudentCompetency','2022-07-02 11:52:37',2,6,13,9,'enrollment',NULL);
 INSERT INTO `cbl_student_competencies` VALUES (655,'Slate\\CBL\\StudentCompetency','2022-07-02 11:52:37',2,6,14,9,'enrollment',NULL);
+INSERT INTO `cbl_student_competencies` VALUES (656,'Slate\\CBL\\StudentCompetency','2022-12-29 20:57:09',2,28,13,9,'enrollment',NULL);

--- a/php-classes/Slate/CBL/StudentCompetency.php
+++ b/php-classes/Slate/CBL/StudentCompetency.php
@@ -302,6 +302,12 @@ class StudentCompetency extends \ActiveRecord
 
     protected static function sortDemonstrations($a, $b)
     {
+        if ($a['Override'] === true) {
+            return 1;
+        } elseif ($b['Override'] === true) {
+            return -1;
+        }
+
         if (
             !empty($a['DemonstrationDate'])
             && !empty($b['DemonstrationDate'])


### PR DESCRIPTION
While doing work on the new ratings backend I noticed a obscure bug that has potentially been around for a while:

When one or more ratings are added _after_ an override for a given skill, they are only shown and only count towards performance level if there are enough ratings to completely flush out the override—otherwise if the override was entered first it flushes out all ratings

This also had a tangential consequence of the Checkmark not being shown on the student progress dashboard for the skill where a non-override rating was being bumped

This PR fixes the bug, while adding a new test case to the fixture data under student5 at HW.2, and adds test coverage for calculations, student progress dashboard rendering, and teacher progress dashboard rendering.

## Scenario

- Three ratings of 8 are logged for HW.2.1–3
- Four overrides are logged for HW.2.2–5
- Two ratings of 10 are logged for HW.2.3 and HW.2.5

![Screen Shot 2022-12-30 at 8 09 38 PM](https://user-images.githubusercontent.com/458494/210120587-fe71bb5f-3bdf-4776-93d4-5d7a31c7337e.png)

## Before

![Screen Shot 2022-12-30 at 8 07 40 PM](https://user-images.githubusercontent.com/458494/210120554-601174cc-b743-462a-bc40-b3496aadba12.png)

## After

![Screen Shot 2022-12-30 at 8 05 56 PM](https://user-images.githubusercontent.com/458494/210120523-0d24c2a1-159a-4768-a700-f592c2f770bf.png)

## Questions

- [ ] Is 8.8 the correct performance calculation in this case?
- [ ] Is +0.8 the correct growth calculation in this case?