### PR TITLE
fix(omnibar): ensure omnibar overlaps app content [#425]

### DIFF
--- a/sencha-workspace/packages/slate-cbl/sass/etc/all.scss
+++ b/sencha-workspace/packages/slate-cbl/sass/etc/all.scss
@@ -7,3 +7,8 @@
     $level-colors-medium,
     $level-colors-dark
 );
+
+div[id^='slate-cbl-'][id*='-picker'],
+.x-css-shadow {
+    z-index: 10 !important;
+}


### PR DESCRIPTION
Lowers the z-index for dropdown menus in the header so that the omnibar is on top