### PR TITLE
fix(tasks-teacher): restore Created sort after archived sort

### DIFF
--- a/sencha-workspace/SlateTasksTeacher/app/view/StudentsGrid.js
+++ b/sencha-workspace/SlateTasksTeacher/app/view/StudentsGrid.js
@@ -29,15 +29,13 @@ Ext.define('SlateTasksTeacher.view.StudentsGrid', function() {
                 }],
                 sorters: [{
                     sorterFn: function(a, b) {
-                        return (
-                            a.get('Status') === b.get('Status') ?
-                            0 :
-                            (
-                                a.get('Status') === 'archived' ?
-                                1 :
-                                -1
-                            )
-                        )
+                        // sort archived tasks to end first
+                        if (a.get('Status') !== b.get('Status')) {
+                            return a.get('Status') === 'archived' ? 1 : -1;
+                        }
+
+                        // sort created date second
+                        return a.get('Created') < b.get('Created') ? 1 : -1;
                     }
                 }]
             },


### PR DESCRIPTION
Sorting by archived status was layered on top of the original sort in the lower store that orders tasks from newest to oldest. After multiple re-sorts at the top layer though the original newest->oldest sort could be lost. This change makes newest->oldest an explicit secondary sort when reordering tasks by status