### PR TITLE
fix: show previous portfolios for enrollment

### DIFF
--- a/static-webapps/slate-portfolio-manager/src/views/AdvancedPortfolioManager/AdvancedPortfolioSidebar/AdvancedPortfolioSidebar.vue
+++ b/static-webapps/slate-portfolio-manager/src/views/AdvancedPortfolioManager/AdvancedPortfolioSidebar/AdvancedPortfolioSidebar.vue
@@ -139,7 +139,6 @@ export default {
       }));
     },
 
-    // TODO:  We no longer need this property for this component, but it is being passed throughout the component hierarchy, so look into it before removing
     visibleLevels() {
       const details = this.studentCompetencyDetails;
       return details ? details.data.map((portfolio) => portfolio.Level) : [];

--- a/static-webapps/slate-portfolio-manager/src/views/AdvancedPortfolioManager/AdvancedPortfolioSidebar/AdvancedPortfolioSidebar.vue
+++ b/static-webapps/slate-portfolio-manager/src/views/AdvancedPortfolioManager/AdvancedPortfolioSidebar/AdvancedPortfolioSidebar.vue
@@ -62,26 +62,27 @@
 
       <ol class="list-unstyled">
         <li
-          v-for="Level in availableLevels"
+          v-for="Level in levels"
           :key="Level"
         >
-          <new-level-panel
-            :Level="Level"
-            :StudentID="studentCompetencyDetails.Student.ID"
-            :CompetencyID="studentCompetencyDetails.Competency.ID"
-          />
-        </li>
-        <li
-          v-for="portfolio in studentCompetencyDetails.data"
-          :key="portfolio.ID"
-        >
-          <level-panel
-            :portfolio="portfolio"
-            :demonstrations="demonstrations"
-            :skills-by-i-d="skillsByID"
-            :show-hidden-items="showHiddenItems"
-            :visible-levels="visibleLevels"
-          />
+          <template v-if="Level.portfolio">
+            <level-panel
+              v-if="Level.portfolio"
+              :portfolio="Level.portfolio"
+              :demonstrations="demonstrations"
+              :skills-by-i-d="skillsByID"
+              :show-hidden-items="showHiddenItems"
+              :visible-levels="visibleLevels"
+            />
+          </template>
+          <template v-else>
+            <new-level-panel
+              v-if="!Level.portfolio"
+              :Level="Level.level"
+              :StudentID="studentCompetencyDetails.Student.ID"
+              :CompetencyID="studentCompetencyDetails.Competency.ID"
+            />
+          </template>
         </li>
       </ol>
     </template>
@@ -130,11 +131,15 @@ export default {
   computed: {
     ...mapStores(useCompetency, useDemonstration, useStudentCompetency, useDemonstrationSkill),
 
-    availableLevels() {
-      const maxLevel = Math.max(this.$site.minLevel - 1, ...this.visibleLevels);
-      return range(maxLevel + 1, this.$site.maxLevel + 1).reverse();
+    levels() {
+      const levelRange = range(this.$site.minLevel, this.$site.maxLevel + 1).reverse();
+      return levelRange.map((level) => ({
+        level,
+        portfolio: this.studentCompetencyDetails.data.find((item) => item.Level === level),
+      }));
     },
 
+    // TODO:  We no longer need this property for this component, but it is being passed throughout the component hierarchy, so look into it before removing
     visibleLevels() {
       const details = this.studentCompetencyDetails;
       return details ? details.data.map((portfolio) => portfolio.Level) : [];

--- a/static-webapps/slate-portfolio-manager/src/views/AdvancedPortfolioManager/AdvancedPortfolioSidebar/AdvancedPortfolioSidebar.vue
+++ b/static-webapps/slate-portfolio-manager/src/views/AdvancedPortfolioManager/AdvancedPortfolioSidebar/AdvancedPortfolioSidebar.vue
@@ -72,7 +72,7 @@
               :demonstrations="demonstrations"
               :skills-by-i-d="skillsByID"
               :show-hidden-items="showHiddenItems"
-              :visible-levels="visibleLevels"
+              :enrolled-levels="enrolledLevels"
             />
           </template>
           <template v-else>
@@ -139,7 +139,7 @@ export default {
       }));
     },
 
-    visibleLevels() {
+    enrolledLevels() {
       const details = this.studentCompetencyDetails;
       return details ? details.data.map((portfolio) => portfolio.Level) : [];
     },

--- a/static-webapps/slate-portfolio-manager/src/views/AdvancedPortfolioManager/AdvancedPortfolioSidebar/LevelPanel.vue
+++ b/static-webapps/slate-portfolio-manager/src/views/AdvancedPortfolioManager/AdvancedPortfolioSidebar/LevelPanel.vue
@@ -56,7 +56,7 @@
           v-bind="skillDemo"
           :show-hidden-items="showHiddenItems"
           :level="portfolio.Level"
-          :visible-levels="visibleLevels"
+          :enrolled-levels="enrolledLevels"
           @refetch="refetch"
         />
         <div
@@ -94,7 +94,7 @@ export default {
   },
 
   props: {
-    visibleLevels: {
+    enrolledLevels: {
       type: Array,
       default: () => [],
     },
@@ -186,7 +186,7 @@ export default {
     },
 
     canDelete() {
-      const nextLevel = this.visibleLevels.find((level) => level > this.portfolio.Level);
+      const nextLevel = this.enrolledLevels.find((level) => level > this.portfolio.Level);
       return this.preppedSkillDemos.length === 0 && !nextLevel;
     },
   },

--- a/static-webapps/slate-portfolio-manager/src/views/AdvancedPortfolioManager/AdvancedPortfolioSidebar/SkillDemoCard.vue
+++ b/static-webapps/slate-portfolio-manager/src/views/AdvancedPortfolioManager/AdvancedPortfolioSidebar/SkillDemoCard.vue
@@ -115,7 +115,7 @@ const shortDate = (value) => {
 
 export default {
   props: {
-    visibleLevels: {
+    enrolledLevels: {
       type: Array,
       default: () => [],
     },
@@ -166,9 +166,9 @@ export default {
       return `${FirstName} ${LastName}`;
     },
     targetLevels() {
-      const visibleLevels = this.visibleLevels.slice();
-      const higherLevels = visibleLevels.filter((l) => l > this.level);
-      const lowerLevels = visibleLevels.filter((l) => l < this.level);
+      const enrolledLevels = this.enrolledLevels.slice();
+      const higherLevels = enrolledLevels.filter((l) => l > this.level);
+      const lowerLevels = enrolledLevels.filter((l) => l < this.level);
       const targetLevels = [];
       if (higherLevels.length) {
         targetLevels.push(Math.min(...higherLevels));

--- a/static-webapps/slate-portfolio-manager/src/views/AdvancedPortfolioManager/AdvancedPortfolioSidebar/SkillDemos.vue
+++ b/static-webapps/slate-portfolio-manager/src/views/AdvancedPortfolioManager/AdvancedPortfolioSidebar/SkillDemos.vue
@@ -25,7 +25,7 @@
         :effective="demo.effective"
         :show-hidden-items="showHiddenItems"
         :level="level"
-        :visible-levels="visibleLevels"
+        :enrolled-levels="enrolledLevels"
         @refetch="$emit('refetch')"
       />
     </ol>
@@ -65,7 +65,7 @@ export default {
       type: Array,
       default: () => [],
     },
-    visibleLevels: {
+    enrolledLevels: {
       type: Array,
       default: () => [],
     },


### PR DESCRIPTION
Currently the Portfolio Manage sidebar does not show any levels below the lowest level with a portfolio.  This means users cannot enroll in those levels.  This fix will change the behavior of the application, showing all levels, and enabling enrollment in those levels.

One note: a computed property "visibleLevels" exists in the AdvancedPortfolioSidebar component.  This property returns an array of the levels with portfolios.  Now that we are showing all levels in the sidebar, this property is no longer used in this component, but it is passed down to and used in subcomponents:

- LevelPanel: used to determine if a portfolio can be deleted - only topmost portfolios can be deleted.
- SkillDemoCard: used to determine whether levels are valid targets for drag-and-drop operations.

While the function of this property is the same, technically since we are now showing all levels, it might be better named levelsWithPortfolios or enrolledLevels something similar.  @themightychris  Let me know if you think a change like this would be warranted.